### PR TITLE
fix: isolate where option query

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -117,7 +117,7 @@ export async function paginate<T>(
     }
 
     if (config.where) {
-        queryBuilder = queryBuilder.andWhere(new Brackets(queryBuilder => queryBuilder.andWhere(config.where)))
+        queryBuilder = queryBuilder.andWhere(new Brackets(queryBuilder => queryBuilder.andWhere(config.where))) // Postgres fix (https://github.com/ppetzold/nestjs-paginate/pull/97)
     }
 
     if (query.search && config.searchableColumns) {


### PR DESCRIPTION
An attempt to resolve https://github.com/ppetzold/nestjs-paginate/issues/96.

New additional tests might be needed.