### PR TITLE
feat: added support for Fastify requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,15 @@
         }
       }
     },
+    "@fastify/ajv-compiler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
+      "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.6"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -1166,6 +1175,12 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -1281,6 +1296,12 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
     "are-we-there-yet": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
@@ -1340,6 +1361,24 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true
+    },
+    "avvio": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.2.tgz",
+      "integrity": "sha512-XW2CMCmZaCmCCsIaJaLKxAzPwF37fXi1KGxNOvedOpeisLdmxZnblGc3hpHWYnlP+KOUxZsazh43WXNHgXpbqw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.1",
+        "queue-microtask": "^1.1.2"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1693,6 +1732,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -2230,6 +2275,12 @@
       "dev": true,
       "optional": true
     },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2261,10 +2312,69 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-json-stringify": {
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.11.tgz",
+      "integrity": "sha512-J6rw31EvrT/PTZ4xi5Sf/NjYt5jF8tAPVzIi82qmfD4niAwBbHvUB99H6ipHWEaNQKXXpoyG7THBVsbVPo9prw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.11.0",
+        "deepmerge": "^4.2.2",
+        "rfdc": "^1.2.0",
+        "string-similarity": "^4.0.1"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-redact": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
+    "fastify": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.22.1.tgz",
+      "integrity": "sha512-TeA4+TzI7VuJrjTNqoxtSXwPEYfCwpT8j9Z3j9WrL8nrt+1bE9G0rP9hLJyvbg4it56p68YsHVhKOee69xyfmA==",
+      "dev": true,
+      "requires": {
+        "@fastify/ajv-compiler": "^1.0.0",
+        "abstract-logging": "^2.0.0",
+        "avvio": "^7.1.2",
+        "fast-json-stringify": "^2.5.2",
+        "fastify-error": "^0.3.0",
+        "fastify-warning": "^0.2.0",
+        "find-my-way": "^4.1.0",
+        "flatstr": "^1.0.12",
+        "light-my-request": "^4.2.0",
+        "pino": "^6.13.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.1.4",
+        "secure-json-parse": "^2.0.0",
+        "semver": "^7.3.2",
+        "tiny-lru": "^7.0.0"
+      }
+    },
+    "fastify-error": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
+      "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==",
+      "dev": true
+    },
+    "fastify-warning": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+      "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
       "dev": true
     },
     "fastq": {
@@ -2309,6 +2419,18 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-my-way": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz",
+      "integrity": "sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==",
+      "dev": true,
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "safe-regex2": "^2.0.0",
+        "semver-store": "^0.3.0"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2328,6 +2450,12 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+      "dev": true
     },
     "flatted": {
       "version": "3.2.2",
@@ -2358,6 +2486,12 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true
     },
     "fs-minipass": {
       "version": "1.2.7",
@@ -2749,6 +2883,12 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
     "is-ci": {
@@ -3542,6 +3682,38 @@
         "type-check": "~0.4.0"
       }
     },
+    "light-my-request": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.6.0.tgz",
+      "integrity": "sha512-wQWGwMr7l7fzYPzzzutRoEI1vuREpIpJpTi3t8cHlGdsnBrOF5iR559Bkh+nkDGgnUJtNuuutjnqbxP7zPWKkA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.1.0",
+        "cookie": "^0.4.0",
+        "fastify-warning": "^0.2.0",
+        "set-cookie-parser": "^2.4.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4151,6 +4323,27 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
+    "pino": {
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
+      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "dev": true,
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "fastify-warning": "^0.2.0",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
+      "dev": true
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -4232,6 +4425,16 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -4255,6 +4458,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true
     },
     "rc": {
@@ -4416,10 +4625,22 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
     "rimraf": {
@@ -4463,6 +4684,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dev": true,
+      "requires": {
+        "ret": "~0.2.0"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4484,6 +4714,12 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -4493,10 +4729,22 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "semver-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
+      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
     },
     "sha.js": {
@@ -4551,6 +4799,16 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dev": true,
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "source-map": {
@@ -4630,6 +4888,12 @@
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -4798,6 +5062,12 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
+    "tiny-lru": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
       "dev": true
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "fastify": "^3.22.1",
     "jest": "^27.2.5",
     "prettier": "^2.4.1",
     "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.1.1",
     "express": "^4.17.1",
+    "fastify": "^3.22.1",
     "typeorm": "^0.2.38"
   },
   "jest": {

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -1,6 +1,7 @@
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants'
 import { HttpArgumentsHost, CustomParamFactory, ExecutionContext } from '@nestjs/common/interfaces'
-import { Request } from 'express'
+import { Request as ExpressRequest } from 'express'
+import { FastifyRequest } from 'fastify'
 import { Paginate, PaginateQuery } from './decorator'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -15,16 +16,31 @@ function getParamDecoratorFactory<T>(decorator: Function): CustomParamFactory {
 }
 const decoratorfactory = getParamDecoratorFactory<PaginateQuery>(Paginate)
 
-function contextFactory(query: Request['query']): Partial<ExecutionContext> {
+function expressContextFactory(query: ExpressRequest['query']): Partial<ExecutionContext> {
     const mockContext: Partial<ExecutionContext> = {
         switchToHttp: (): HttpArgumentsHost =>
             Object({
-                getRequest: (): Partial<Request> =>
+                getRequest: (): Partial<ExpressRequest> =>
                     Object({
                         protocol: 'http',
                         get: () => 'localhost',
-                        baseUrl: '',
-                        path: '/items',
+                        originalUrl: '/items?search=2423',
+                        query: query,
+                    }),
+            }),
+    }
+    return mockContext
+}
+
+function fastifyContextFactory(query: FastifyRequest['query']): Partial<ExecutionContext> {
+    const mockContext: Partial<ExecutionContext> = {
+        switchToHttp: (): HttpArgumentsHost =>
+            Object({
+                getRequest: (): Partial<FastifyRequest> =>
+                    Object({
+                        protocol: 'http',
+                        hostname: 'localhost',
+                        url: '/items?search=2423',
                         query: query,
                     }),
             }),
@@ -33,8 +49,8 @@ function contextFactory(query: Request['query']): Partial<ExecutionContext> {
 }
 
 describe('Decorator', () => {
-    it('should handle undefined query fields', () => {
-        const context = contextFactory({})
+    it('should handle express undefined query fields', () => {
+        const context = expressContextFactory({})
 
         const result: PaginateQuery = decoratorfactory(null, context)
 
@@ -49,8 +65,53 @@ describe('Decorator', () => {
         })
     })
 
-    it('should handle defined query fields', () => {
-        const context = contextFactory({
+    it('should handle fastify undefined query fields', () => {
+        const context = fastifyContextFactory({})
+
+        const result: PaginateQuery = decoratorfactory(null, context)
+
+        expect(result).toStrictEqual({
+            page: undefined,
+            limit: undefined,
+            sortBy: undefined,
+            search: undefined,
+            searchBy: undefined,
+            filter: undefined,
+            path: 'http://localhost/items',
+        })
+    })
+
+    it('should handle express defined query fields', () => {
+        const context = expressContextFactory({
+            page: '1',
+            limit: '20',
+            sortBy: ['id:ASC', 'createdAt:DESC'],
+            search: 'white',
+            'filter.name': '$not:$eq:Kitty',
+            'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
+        })
+
+        const result: PaginateQuery = decoratorfactory(null, context)
+
+        expect(result).toStrictEqual({
+            page: 1,
+            limit: 20,
+            sortBy: [
+                ['id', 'ASC'],
+                ['createdAt', 'DESC'],
+            ],
+            search: 'white',
+            searchBy: undefined,
+            path: 'http://localhost/items',
+            filter: {
+                name: '$not:$eq:Kitty',
+                createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
+            },
+        })
+    })
+
+    it('should handle fastify defined query fields', () => {
+        const context = fastifyContextFactory({
             page: '1',
             limit: '20',
             sortBy: ['id:ASC', 'createdAt:DESC'],

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -15,7 +15,16 @@ export interface PaginateQuery {
 export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionContext): PaginateQuery => {
     const request: Request = ctx.switchToHttp().getRequest()
     const { query } = request
-    const path = request.protocol + '://' + request.get('host') + request.baseUrl + request.path
+
+    // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
+    let originalUrl;
+    if (request.originalUrl) {
+        originalUrl = request.protocol + '://' + request.get('host') + request.originalUrl;
+    } else {
+        originalUrl = request.protocol + '://' + request.hostname + request.url;
+    }
+    const urlParts = new URL(originalUrl);
+    const path = urlParts.protocol + '//' + urlParts.host + urlParts.pathname;
 
     const sortBy: [string, string][] = []
     const searchBy: string[] = []

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -17,14 +17,14 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
     const { query } = request
 
     // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
-    let originalUrl;
+    let originalUrl
     if (request.originalUrl) {
-        originalUrl = request.protocol + '://' + request.get('host') + request.originalUrl;
+        originalUrl = request.protocol + '://' + request.get('host') + request.originalUrl
     } else {
-        originalUrl = request.protocol + '://' + request.hostname + request.url;
+        originalUrl = request.protocol + '://' + request.hostname + request.url
     }
-    const urlParts = new URL(originalUrl);
-    const path = urlParts.protocol + '//' + urlParts.host + urlParts.pathname;
+    const urlParts = new URL(originalUrl)
+    const path = urlParts.protocol + '//' + urlParts.host + urlParts.pathname
 
     const sortBy: [string, string][] = []
     const searchBy: string[] = []


### PR DESCRIPTION
I ran into issues using this package as I'm using fastify which doesn't have the same request methods as express.

So I've created this PR. However I'm a little unsure if I went the right way with checking the request type. I looked for the `originalUrl` property which is only on Express.

I'm not happy with that solution but as there is no way to check something is an instance of an interface I'm not sure what else I can do. Any Suggestions for a better solution would be great.

