### PR TITLE
Better splitting of the filter string to allow for filter values that contain a colon

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -442,46 +442,46 @@ describe('paginate', () => {
     })
 
     it.each([
-        {operator: '$eq', result: true},
-        {operator: '$gte', result: true},
-        {operator: '$gt', result: true},
-        {operator: '$in', result: true},
-        {operator: '$null', result: true},
-        {operator: '$lt', result: true},
-        {operator: '$lte', result: true},
-        {operator: '$not', result: true},
-        {operator: '$fake', result: false},
-    ])('should check operator "$operator" valid is $result', ({operator, result}) => {
+        { operator: '$eq', result: true },
+        { operator: '$gte', result: true },
+        { operator: '$gt', result: true },
+        { operator: '$in', result: true },
+        { operator: '$null', result: true },
+        { operator: '$lt', result: true },
+        { operator: '$lte', result: true },
+        { operator: '$not', result: true },
+        { operator: '$fake', result: false },
+    ])('should check operator "$operator" valid is $result', ({ operator, result }) => {
         expect(isOperator(operator)).toStrictEqual(result)
-    });
+    })
 
     it.each([
-        {operator: '$eq', name: 'Equal'},
-        {operator: '$gt', name: 'MoreThan'},
-        {operator: '$gte', name: 'MoreThanOrEqual'},
-        {operator: '$in', name: 'In'},
-        {operator: '$null', name: 'IsNull'},
-        {operator: '$lt', name: 'LessThan'},
-        {operator: '$lte', name: 'LessThanOrEqual'},
-        {operator: '$not', name: 'Not'},
-    ])('should get operator function $name for "$operator"', ({operator, name}) => {
+        { operator: '$eq', name: 'Equal' },
+        { operator: '$gt', name: 'MoreThan' },
+        { operator: '$gte', name: 'MoreThanOrEqual' },
+        { operator: '$in', name: 'In' },
+        { operator: '$null', name: 'IsNull' },
+        { operator: '$lt', name: 'LessThan' },
+        { operator: '$lte', name: 'LessThanOrEqual' },
+        { operator: '$not', name: 'Not' },
+    ])('should get operator function $name for "$operator"', ({ operator, name }) => {
         const func = getOperatorFn<CatEntity>(operator as FilterOperator)
         expect(func.name).toStrictEqual(name)
     })
 
     it.each([
-        {string: '$eq:value', tokens: [null, '$eq', 'value']},
-        {string: '$eq:val:ue', tokens: [null, '$eq', 'val:ue']},
-        {string: '$in:value1,value2,value3', tokens: [null, '$in', 'value1,value2,value3']},
-        {string: 'value', tokens: [null, '$eq', 'value']},
-        {string: 'val:ue', tokens: [null, '$eq', 'val:ue']},
-        {string: '$not:value', tokens: [null, '$not', 'value']},
-        {string: '$eq:$not:value', tokens: ['$eq', '$not', 'value']},
-        {string: '$eq:$null', tokens: ['$eq', '$null']},
-        {string: '$null', tokens: [null, '$null']},
-        {string: '', tokens: [null, '$eq', '']},
-        {string: '$eq:$not:$in:value', tokens: []},
-    ])('should get filter tokens for "$string"', ({string, tokens}) => {
+        { string: '$eq:value', tokens: [null, '$eq', 'value'] },
+        { string: '$eq:val:ue', tokens: [null, '$eq', 'val:ue'] },
+        { string: '$in:value1,value2,value3', tokens: [null, '$in', 'value1,value2,value3'] },
+        { string: 'value', tokens: [null, '$eq', 'value'] },
+        { string: 'val:ue', tokens: [null, '$eq', 'val:ue'] },
+        { string: '$not:value', tokens: [null, '$not', 'value'] },
+        { string: '$eq:$not:value', tokens: ['$eq', '$not', 'value'] },
+        { string: '$eq:$null', tokens: ['$eq', '$null'] },
+        { string: '$null', tokens: [null, '$null'] },
+        { string: '', tokens: [null, '$eq', ''] },
+        { string: '$eq:$not:$in:value', tokens: [] },
+    ])('should get filter tokens for "$string"', ({ string, tokens }) => {
         expect(getFilterTokens(string)).toStrictEqual(tokens)
     })
 })

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1,5 +1,13 @@
 import { createConnection, Repository, Column, In } from 'typeorm'
-import { Paginated, paginate, PaginateConfig, FilterOperator } from './paginate'
+import {
+    Paginated,
+    paginate,
+    PaginateConfig,
+    FilterOperator,
+    isOperator,
+    getOperatorFn,
+    getFilterTokens,
+} from './paginate'
 import { PaginateQuery } from './decorator'
 import { Entity, PrimaryGeneratedColumn, CreateDateColumn } from 'typeorm'
 import { HttpException } from '@nestjs/common'
@@ -431,5 +439,49 @@ describe('paginate', () => {
         } catch (err) {
             expect(err).toBeInstanceOf(HttpException)
         }
+    })
+
+    it.each([
+        {operator: '$eq', result: true},
+        {operator: '$gte', result: true},
+        {operator: '$gt', result: true},
+        {operator: '$in', result: true},
+        {operator: '$null', result: true},
+        {operator: '$lt', result: true},
+        {operator: '$lte', result: true},
+        {operator: '$not', result: true},
+        {operator: '$fake', result: false},
+    ])('should check operator "$operator" valid is $result', ({operator, result}) => {
+        expect(isOperator(operator)).toStrictEqual(result)
+    });
+
+    it.each([
+        {operator: '$eq', name: 'Equal'},
+        {operator: '$gt', name: 'MoreThan'},
+        {operator: '$gte', name: 'MoreThanOrEqual'},
+        {operator: '$in', name: 'In'},
+        {operator: '$null', name: 'IsNull'},
+        {operator: '$lt', name: 'LessThan'},
+        {operator: '$lte', name: 'LessThanOrEqual'},
+        {operator: '$not', name: 'Not'},
+    ])('should get operator function $name for "$operator"', ({operator, name}) => {
+        const func = getOperatorFn<CatEntity>(operator as FilterOperator)
+        expect(func.name).toStrictEqual(name)
+    })
+
+    it.each([
+        {string: '$eq:value', tokens: [null, '$eq', 'value']},
+        {string: '$eq:val:ue', tokens: [null, '$eq', 'val:ue']},
+        {string: '$in:value1,value2,value3', tokens: [null, '$in', 'value1,value2,value3']},
+        {string: 'value', tokens: [null, '$eq', 'value']},
+        {string: 'val:ue', tokens: [null, '$eq', 'val:ue']},
+        {string: '$not:value', tokens: [null, '$not', 'value']},
+        {string: '$eq:$not:value', tokens: ['$eq', '$not', 'value']},
+        {string: '$eq:$null', tokens: ['$eq', '$null']},
+        {string: '$null', tokens: [null, '$null']},
+        {string: '', tokens: [null, '$eq', '']},
+        {string: '$eq:$not:$in:value', tokens: []},
+    ])('should get filter tokens for "$string"', ({string, tokens}) => {
+        expect(getFilterTokens(string)).toStrictEqual(tokens)
     })
 })

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -66,8 +66,8 @@ export enum FilterOperator {
     NOT = '$not',
 }
 
-export function isOperator(value: any): value is FilterOperator {
-    return values(FilterOperator).includes(value)
+export function isOperator(value: unknown): value is FilterOperator {
+    return values(FilterOperator).includes(value as any)
 }
 
 export function getOperatorFn<T>(op: FilterOperator): (...args: any[]) => FindOperator<T> {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -92,9 +92,18 @@ export function getOperatorFn<T>(op: FilterOperator): (...args: any[]) => FindOp
 }
 
 export function getFilterTokens(raw: string): string[] {
-    const tokens = raw.split(':')
+    const tokens = []
+    const matches = raw.match(/(\$\w+):/g)
+
+    if (matches) {
+        const value = raw.replace(matches.join(''), '')
+        tokens.push(...matches.map((token) => token.substring(0, token.length - 1)), value)
+    } else {
+        tokens.push(raw)
+    }
+
     if (tokens.length === 0 || tokens.length > 3) {
-        return [];
+        return []
     } else if (tokens.length === 2) {
         if (tokens[1] !== FilterOperator.NULL) {
             tokens.unshift(null)
@@ -107,7 +116,7 @@ export function getFilterTokens(raw: string): string[] {
         }
     }
 
-    return tokens;
+    return tokens
 }
 
 function parseFilter<T>(query: PaginateQuery, config: PaginateConfig<T>) {


### PR DESCRIPTION
First step was to split out some parts of larger paginate function into smaller functions and added tests.

Two of the tests contain filter values that have a `:` and they currently fail. Need to make those tests work.