### PR TITLE
fix: isolate all where clauses

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -227,13 +227,13 @@ export async function paginate<T>(
         for (const column of searchBy) {
             search.push({ [column]: ILike(`%${query.search}%`) })
         }
-        queryBuilder = queryBuilder.andWhere(search)
+        queryBuilder = queryBuilder.andWhere(new Brackets((queryBuilder) => queryBuilder.andWhere(search)))
     }
 
     if (query.filter) {
         const filter = parseFilter<T>(query, config)
 
-        queryBuilder = queryBuilder.andWhere(filter)
+        queryBuilder = queryBuilder.andWhere(new Brackets((queryBuilder) => queryBuilder.andWhere(filter)))
     }
 
     ;[items, totalItems] = await queryBuilder.getManyAndCount()


### PR DESCRIPTION
As previously described in https://github.com/ppetzold/nestjs-paginate/issues/96, there is an non-intuitive behavior of `andWhere` method in TypeORM's QueryBuilder, resulting in mixing of different search/filter options for this library. The issue seems to be again primarily related to Postgres, as discussed before in https://github.com/ppetzold/nestjs-paginate/pull/97.

#### Example
Following the example from https://github.com/ppetzold/nestjs-paginate/issues/96...

The library implementation in `SomeService`:
```
paginate(query, this.someRepository, {
  ...,
  searchableColumns: [<property1>, <property2>],
  filterableColumns: {
    <property3>: [FilterOperator.EQ, FilterOperator.IN]
  }
}
```
and the following request:
```
path/to/endpoint?search=<value1>&filter.<property3>=$in:<value2>,<value3>
```
will return records that fit this query:
`WHERE (property1 ILIKE value1) OR (property2 ILIKE value 1) AND (property3 IN (value2, value3)`
which thanks to the operator precedence is the same as:
`WHERE (property1 ILIKE value1) OR ((property2 ILIKE value 1) AND (property3 IN (value2, value3))`

Again, as in https://github.com/ppetzold/nestjs-paginate/issues/96, I assume that instead of mixing different search/filter options together like above we prefer the following query:
`WHERE ((property1 ILIKE value1) OR (property2 ILIKE value 1)) AND (property3 IN (value2, value3)`