### PR TITLE
Support of betweet operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pagination and filtering helper method for TypeORM repositories or query builder
 - Pagination conforms to [JSON:API](https://jsonapi.org/)
 - Sort by multiple columns
 - Search across columns
-- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`)
+- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`)
 
 ## Installation
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -346,6 +346,26 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$gte:4')
     })
 
+    it('should return result based on between range filter', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            filterableColumns: {
+                age: [FilterOperator.BTW],
+            },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: {
+                age: '$btw:4,6',
+            },
+        }
+
+        const result = await paginate<CatEntity>(query, repo, config)
+
+        expect(result.data).toStrictEqual([cats[0], cats[2]])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$btw:4,6')
+    })
+
     it('should return result based on is null query', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],
@@ -449,6 +469,7 @@ describe('paginate', () => {
         { operator: '$null', result: true },
         { operator: '$lt', result: true },
         { operator: '$lte', result: true },
+        { operator: '$btw', result: true },
         { operator: '$not', result: true },
         { operator: '$fake', result: false },
     ])('should check operator "$operator" valid is $result', ({ operator, result }) => {
@@ -463,6 +484,7 @@ describe('paginate', () => {
         { operator: '$null', name: 'IsNull' },
         { operator: '$lt', name: 'LessThan' },
         { operator: '$lte', name: 'LessThanOrEqual' },
+        { operator: '$btw', name: 'Between' },
         { operator: '$not', name: 'Not' },
     ])('should get operator function $name for "$operator"', ({ operator, name }) => {
         const func = getOperatorFn<CatEntity>(operator as FilterOperator)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -14,6 +14,7 @@ import {
     Not,
     ILike,
     Brackets,
+    Between,
 } from 'typeorm'
 import { PaginateQuery } from './decorator'
 import { ServiceUnavailableException } from '@nestjs/common'
@@ -63,6 +64,7 @@ export enum FilterOperator {
     NULL = '$null',
     LT = '$lt',
     LTE = '$lte',
+    BTW = '$btw',
     NOT = '$not',
 }
 
@@ -86,6 +88,8 @@ export function getOperatorFn<T>(op: FilterOperator): (...args: any[]) => FindOp
             return LessThan
         case FilterOperator.LTE:
             return LessThanOrEqual
+        case FilterOperator.BTW:
+            return Between
         case FilterOperator.NOT:
             return Not
     }
@@ -144,7 +148,8 @@ function parseFilter<T>(query: PaginateQuery, config: PaginateConfig<T>) {
             }
             if (isOperator(op1)) {
                 const args = op1 === FilterOperator.IN ? value.split(',') : value
-                filter[column] = getOperatorFn<T>(op1)(args)
+                filter[column] =
+                    op1 === FilterOperator.BTW ? getOperatorFn<T>(op1)(args[0], args[1]) : getOperatorFn<T>(op1)(args)
             }
             if (isOperator(op2)) {
                 filter[column] = getOperatorFn<T>(op2)(filter[column])


### PR DESCRIPTION
Were added support for between operator that was mentioned in the [#77](https://github.com/ppetzold/nestjs-paginate/issues/77) issue.

Were used similar approach as with `$in` operator where we pass arguments separating them by a comma.
So operator `btw`(between) takes two arguments separated by a comma and can be used in the next way: `filter.age=$btw:4,6`