### PR TITLE
fix: return only current link for zero results

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -140,7 +140,7 @@ describe('paginate', () => {
         expect(result.data).toStrictEqual(cats.slice(0, 2))
     })
 
-    it('should return correct links', async () => {
+    it('should return correct links for some results', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],
         }
@@ -157,6 +157,27 @@ describe('paginate', () => {
         expect(links.current).toBe('?page=2&limit=2&sortBy=id:ASC')
         expect(links.next).toBe('?page=3&limit=2&sortBy=id:ASC')
         expect(links.last).toBe('?page=3&limit=2&sortBy=id:ASC')
+    })
+
+    it('should return only current link if zero results', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            searchableColumns: ['name']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            page: 1,
+            limit: 2,
+            search: 'Pluto',
+        }
+
+        const { links } = await paginate<CatEntity>(query, repo, config)
+
+        expect(links.first).toBe(undefined)
+        expect(links.previous).toBe(undefined)
+        expect(links.current).toBe('?page=1&limit=2&sortBy=id:ASC&search=Pluto')
+        expect(links.next).toBe(undefined)
+        expect(links.last).toBe(undefined)
     })
 
     it('should default to defaultSortBy if query sortBy does not exist', async () => {

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -162,7 +162,7 @@ describe('paginate', () => {
     it('should return only current link if zero results', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],
-            searchableColumns: ['name']
+            searchableColumns: ['name'],
         }
         const query: PaginateQuery = {
             path: '',

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -278,7 +278,7 @@ export async function paginate<T>(
             previous: page - 1 < 1 ? undefined : buildLink(page - 1),
             current: buildLink(page),
             next: page + 1 > totalPages ? undefined : buildLink(page + 1),
-            last: (page == totalPages || !totalItems) ? undefined : buildLink(totalPages),
+            last: page == totalPages || !totalItems ? undefined : buildLink(totalPages),
         },
     }
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -278,7 +278,7 @@ export async function paginate<T>(
             previous: page - 1 < 1 ? undefined : buildLink(page - 1),
             current: buildLink(page),
             next: page + 1 > totalPages ? undefined : buildLink(page + 1),
-            last: page == totalPages ? undefined : buildLink(totalPages),
+            last: (page == totalPages || !totalItems) ? undefined : buildLink(totalPages),
         },
     }
 


### PR DESCRIPTION
A query resulting in zero records should not, in my opinion, generate the `last` link. Currently, `last` link with `page=0` is returned.

Optionally, this could be also modified for _"faulty"_ queries, such as querying page 2, when there were already no records found on the first page. 