### PR TITLE
bumps typeorm to 0.3.6 - BREAKING CHANGE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,14 +30,14 @@
         "sqlite3": "^5.0.8",
         "ts-jest": "^28.0.3",
         "ts-node": "^10.8.1",
-        "typeorm": "^0.2.45",
+        "typeorm": "^0.3.6",
         "typescript": "^4.7.3"
       },
       "peerDependencies": {
         "@nestjs/common": "^8.4.6",
         "express": "^4.18.1",
         "fastify": "^3.29.0",
-        "typeorm": "^0.2.45"
+        "typeorm": "^0.3.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1484,12 +1484,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
@@ -2551,6 +2545,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2684,12 +2691,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -7111,9 +7118,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
+      "integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
       "dev": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
@@ -7121,26 +7128,32 @@
         "buffer": "^6.0.3",
         "chalk": "^4.1.0",
         "cli-highlight": "^2.1.11",
-        "debug": "^4.3.1",
-        "dotenv": "^8.2.0",
-        "glob": "^7.1.6",
-        "js-yaml": "^4.0.0",
+        "date-fns": "^2.28.0",
+        "debug": "^4.3.3",
+        "dotenv": "^16.0.0",
+        "glob": "^7.2.0",
+        "js-yaml": "^4.1.0",
         "mkdirp": "^1.0.4",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.1.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23",
-        "yargs": "^17.0.1",
-        "zen-observable-ts": "^1.0.0"
+        "yargs": "^17.3.1"
       },
       "bin": {
-        "typeorm": "cli.js"
+        "typeorm": "cli.js",
+        "typeorm-ts-node-commonjs": "cli-ts-node-commonjs.js",
+        "typeorm-ts-node-esm": "cli-ts-node-esm.js"
+      },
+      "engines": {
+        "node": ">= 12.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/typeorm"
       },
       "peerDependencies": {
+        "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.11.14",
         "better-sqlite3": "^7.1.2",
         "hdb-pool": "^0.1.6",
@@ -7152,12 +7165,16 @@
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
-        "redis": "^3.1.1",
+        "redis": "^3.1.1 || ^4.0.0",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.2",
+        "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0"
       },
       "peerDependenciesMeta": {
+        "@google-cloud/spanner": {
+          "optional": true
+        },
         "@sap/hana-client": {
           "optional": true
         },
@@ -7198,6 +7215,9 @@
           "optional": true
         },
         "sqlite3": {
+          "optional": true
+        },
+        "ts-node": {
           "optional": true
         },
         "typeorm-aurora-data-api-driver": {
@@ -7489,22 +7509,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "dev": true,
-      "dependencies": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
       }
     }
   },
@@ -8685,12 +8689,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
@@ -9457,6 +9455,12 @@
         "which": "^2.0.1"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -9551,9 +9555,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true
     },
     "ee-first": {
@@ -12902,9 +12906,9 @@
       }
     },
     "typeorm": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
+      "integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
       "dev": true,
       "requires": {
         "@sqltools/formatter": "^1.2.2",
@@ -12912,18 +12916,18 @@
         "buffer": "^6.0.3",
         "chalk": "^4.1.0",
         "cli-highlight": "^2.1.11",
-        "debug": "^4.3.1",
-        "dotenv": "^8.2.0",
-        "glob": "^7.1.6",
-        "js-yaml": "^4.0.0",
+        "date-fns": "^2.28.0",
+        "debug": "^4.3.3",
+        "dotenv": "^16.0.0",
+        "glob": "^7.2.0",
+        "js-yaml": "^4.1.0",
         "mkdirp": "^1.0.4",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.1.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23",
-        "yargs": "^17.0.1",
-        "zen-observable-ts": "^1.0.0"
+        "yargs": "^17.3.1"
       }
     },
     "typescript": {
@@ -13152,22 +13156,6 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
-    },
-    "zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
-    },
-    "zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "dev": true,
-      "requires": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-paginate",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "author": "Philipp Petzold <ppetzold@protonmail.com>",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-paginate",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "author": "Philipp Petzold <ppetzold@protonmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
@@ -48,7 +48,7 @@
     "sqlite3": "^5.0.8",
     "ts-jest": "^28.0.3",
     "ts-node": "^10.8.1",
-    "typeorm": "^0.2.45",
+    "typeorm": "^0.3.6",
     "typescript": "^4.7.3"
   },
   "dependencies": {
@@ -58,7 +58,7 @@
     "@nestjs/common": "^8.4.6",
     "express": "^4.18.1",
     "fastify": "^3.29.0",
-    "typeorm": "^0.2.45"
+    "typeorm": "^0.3.6"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -1,6 +1,5 @@
 import {
     Repository,
-    FindConditions,
     SelectQueryBuilder,
     FindOperator,
     Equal,
@@ -14,6 +13,7 @@ import {
     ILike,
     Brackets,
     Between,
+    FindOptionsWhere,
 } from 'typeorm'
 import { PaginateQuery } from './decorator'
 import { ServiceUnavailableException } from '@nestjs/common'
@@ -50,7 +50,7 @@ export interface PaginateConfig<T> {
     maxLimit?: number
     defaultSortBy?: SortBy<T>
     defaultLimit?: number
-    where?: FindConditions<T> | FindConditions<T>[]
+    where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
     filterableColumns?: { [key in Column<T>]?: FilterOperator[] }
     withDeleted?: boolean
 }


### PR DESCRIPTION
Closes #239 

This PR bumps typeorm to version 0.3.x which includes breaking changes.
In order for developers to understand nestjs-paginate version should also be brought up to 0.3.x i guess.

Tests where running through.
![image](https://user-images.githubusercontent.com/18501893/174429044-7ce1d51f-4fea-4e1c-a870-0c1c062e1e7d.png)

Happy to accept any feedback!
BR Jakob