### PR TITLE
Customized links

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * https://typeorm.io/select-query-builder#querying-deleted-rows
    */
   withDeleted: false,
+
+  /**
+   * Required: false
+   * Type: boolean
+   * Default: false
+   * Description: Generate relative paths in the resource links.
+   */
+  relativePath: true,
+
+  /**
+   * Required: false
+   * Type: string
+   * Description: Overrides the origin of absolute resource links if set.
+   */
+  origin: 'http://cats.example',
 }
 ```
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -179,7 +179,7 @@ describe('paginate', () => {
         expect(links.current).toBe('/cats?page=2&limit=2&sortBy=id:ASC')
         expect(links.next).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
         expect(links.last).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
-    });
+    })
 
     it('should return an absolute path', async () => {
         const config: PaginateConfig<CatEntity> = {
@@ -200,13 +200,13 @@ describe('paginate', () => {
         expect(links.current).toBe('http://localhost/cats?page=2&limit=2&sortBy=id:ASC')
         expect(links.next).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
         expect(links.last).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
-    });
+    })
 
     it('should return an absolute path with new origin', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],
             relativePath: false,
-            origin: 'http://cats.example'
+            origin: 'http://cats.example',
         }
 
         const query: PaginateQuery = {
@@ -222,7 +222,7 @@ describe('paginate', () => {
         expect(links.current).toBe('http://cats.example/cats?page=2&limit=2&sortBy=id:ASC')
         expect(links.next).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
         expect(links.last).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
-    });
+    })
 
     it('should return only current link if zero results', async () => {
         const config: PaginateConfig<CatEntity> = {

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -160,6 +160,70 @@ describe('paginate', () => {
         expect(links.last).toBe('?page=3&limit=2&sortBy=id:ASC')
     })
 
+    it('should return a relative path', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            relativePath: true,
+        }
+
+        const query: PaginateQuery = {
+            path: 'http://localhost/cats',
+            page: 2,
+            limit: 2,
+        }
+
+        const { links } = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(links.first).toBe('/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.previous).toBe('/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.current).toBe('/cats?page=2&limit=2&sortBy=id:ASC')
+        expect(links.next).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.last).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
+    });
+
+    it('should return an absolute path', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            relativePath: false,
+        }
+
+        const query: PaginateQuery = {
+            path: 'http://localhost/cats',
+            page: 2,
+            limit: 2,
+        }
+
+        const { links } = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(links.first).toBe('http://localhost/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.previous).toBe('http://localhost/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.current).toBe('http://localhost/cats?page=2&limit=2&sortBy=id:ASC')
+        expect(links.next).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.last).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
+    });
+
+    it('should return an absolute path with new origin', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            relativePath: false,
+            origin: 'http://cats.example'
+        }
+
+        const query: PaginateQuery = {
+            path: 'http://localhost/cats',
+            page: 2,
+            limit: 2,
+        }
+
+        const { links } = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(links.first).toBe('http://cats.example/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.previous).toBe('http://cats.example/cats?page=1&limit=2&sortBy=id:ASC')
+        expect(links.current).toBe('http://cats.example/cats?page=2&limit=2&sortBy=id:ASC')
+        expect(links.next).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.last).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
+    });
+
     it('should return only current link if zero results', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -54,9 +54,9 @@ export interface PaginateConfig<T> {
     defaultLimit?: number
     where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
     filterableColumns?: { [key in Column<T>]?: FilterOperator[] }
-    withDeleted?: boolean,
-    relativePath?: boolean,
-    origin?: string,
+    withDeleted?: boolean
+    relativePath?: boolean
+    origin?: string
 }
 
 export enum FilterOperator {
@@ -166,26 +166,26 @@ export async function paginate<T>(
     let page = query.page || 1
     const limit = Math.min(query.limit || config.defaultLimit || 20, config.maxLimit || 100)
     const sortBy = [] as SortBy<T>
-    const searchBy: Column<T>[] = [];
-    let path;
+    const searchBy: Column<T>[] = []
+    let path
 
-    const r = new RegExp('^(?:[a-z+]+:)?//', 'i');
-    let queryOrigin = '';
-    let queryPath = '';
-    if(r.test(query.path)){
-        const url = new URL(query.path);
-        queryOrigin = url.origin;
-        queryPath = url.pathname;
+    const r = new RegExp('^(?:[a-z+]+:)?//', 'i')
+    let queryOrigin = ''
+    let queryPath = ''
+    if (r.test(query.path)) {
+        const url = new URL(query.path)
+        queryOrigin = url.origin
+        queryPath = url.pathname
     } else {
-        queryPath = query.path;
+        queryPath = query.path
     }
 
     if (config.relativePath) {
-        path = queryPath;
+        path = queryPath
     } else if (config.origin) {
-        path = config.origin + queryPath;
+        path = config.origin + queryPath
     } else {
-        path = queryOrigin + queryPath;
+        path = queryOrigin + queryPath
     }
 
     function isEntityKey(entityColumns: Column<T>[], column: string): column is Column<T> {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -54,7 +54,9 @@ export interface PaginateConfig<T> {
     defaultLimit?: number
     where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
     filterableColumns?: { [key in Column<T>]?: FilterOperator[] }
-    withDeleted?: boolean
+    withDeleted?: boolean,
+    relativePath?: boolean,
+    origin?: string,
 }
 
 export enum FilterOperator {
@@ -164,8 +166,27 @@ export async function paginate<T>(
     let page = query.page || 1
     const limit = Math.min(query.limit || config.defaultLimit || 20, config.maxLimit || 100)
     const sortBy = [] as SortBy<T>
-    const searchBy: Column<T>[] = []
-    const path = query.path
+    const searchBy: Column<T>[] = [];
+    let path;
+
+    const r = new RegExp('^(?:[a-z+]+:)?//', 'i');
+    let queryOrigin = '';
+    let queryPath = '';
+    if(r.test(query.path)){
+        const url = new URL(query.path);
+        queryOrigin = url.origin;
+        queryPath = url.pathname;
+    } else {
+        queryPath = query.path;
+    }
+
+    if (config.relativePath) {
+        path = queryPath;
+    } else if (config.origin) {
+        path = config.origin + queryPath;
+    } else {
+        path = queryOrigin + queryPath;
+    }
 
     function isEntityKey(entityColumns: Column<T>[], column: string): column is Column<T> {
         return !!entityColumns.find((c) => c === column)


### PR DESCRIPTION
* Add config parameter to generate relative paths in links, as requested in #214.
* Add config parameter to override origin from query parameters. Useful when running behind a proxy accepting requests at a different url.

__Previous behavior__
Append `?page=...` to `path` from `PaginateQuery` passed to `paginate()` function. `path` can be either a relative or an absolute path.

__New default behavior__
Same as previous behavior.

__Relative paths__
Set `relativePaths = true` in config passed to `paginate()` function. Generated link will no longer include the origin part of the url.

__Override orgin__
Set `origin` to the origin to use instead of the one in the `path` property in the query parameters. I.e. if `origin = 'https://cats.example'`, a request sent to `http://localhost/cats` will get the link `https://cats.example/cats?page=...`