### PR TITLE
Added $ilike operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pagination and filtering helper method for TypeORM repositories or query builder
 - Pagination conforms to [JSON:API](https://jsonapi.org/)
 - Sort by multiple columns
 - Search across columns
-- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`)
+- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`, `$ilike`)
 - Include relations
 
 ## Installation

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1017,6 +1017,7 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.toys.size.height=$eq:1')
     })
 
+
     it('should return result based on filter on embedded on one-to-one relation', async () => {
         const config: PaginateConfig<CatHomeEntity> = {
             relations: ['cat'],
@@ -1144,6 +1145,30 @@ describe('paginate', () => {
         })
         expect(result.data).toStrictEqual([cats[3]])
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$not:Leche&filter.color=white')
+    })
+    
+
+    it('should return result based on $ilike filter', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            filterableColumns: {
+                name: [FilterOperator.ILIKE],
+            },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: {
+                'name': '$ilike:Garf',
+            },
+        }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(result.meta.filter).toStrictEqual({
+            name: '$ilike:Garf',
+        })
+        expect(result.data).toStrictEqual([cats[1]])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$ilike:Garf')
     })
 
     it('should return result based on filter and search term', async () => {
@@ -1338,6 +1363,7 @@ describe('paginate', () => {
         { operator: '$lte', result: true },
         { operator: '$btw', result: true },
         { operator: '$not', result: true },
+        { operator: '$ilike', result: true },
         { operator: '$fake', result: false },
     ])('should check operator "$operator" valid is $result', ({ operator, result }) => {
         expect(isOperator(operator)).toStrictEqual(result)
@@ -1353,12 +1379,14 @@ describe('paginate', () => {
         { operator: '$lte', name: 'LessThanOrEqual' },
         { operator: '$btw', name: 'Between' },
         { operator: '$not', name: 'Not' },
+        { operator: '$ilike', name: 'ILike' },
     ])('should get operator function $name for "$operator"', ({ operator, name }) => {
         const func = OperatorSymbolToFunction.get(operator as FilterOperator)
         expect(func.name).toStrictEqual(name)
     })
 
     it.each([
+        { string: '$ilike:value', tokens: [null, '$ilike', 'value'] },
         { string: '$eq:value', tokens: [null, '$eq', 'value'] },
         { string: '$eq:val:ue', tokens: [null, '$eq', 'val:ue'] },
         { string: '$in:value1,value2,value3', tokens: [null, '$in', 'value1,value2,value3'] },

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1145,7 +1145,6 @@ describe('paginate', () => {
         expect(result.data).toStrictEqual([cats[3]])
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$not:Leche&filter.color=white')
     })
-    
 
     it('should return result based on $ilike filter', async () => {
         const config: PaginateConfig<CatEntity> = {
@@ -1157,7 +1156,7 @@ describe('paginate', () => {
         const query: PaginateQuery = {
             path: '',
             filter: {
-                'name': '$ilike:Garf',
+                name: '$ilike:Garf',
             },
         }
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1017,7 +1017,6 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.toys.size.height=$eq:1')
     })
 
-
     it('should return result based on filter on embedded on one-to-one relation', async () => {
         const config: PaginateConfig<CatHomeEntity> = {
             relations: ['cat'],

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -69,6 +69,7 @@ export enum FilterOperator {
     LTE = '$lte',
     BTW = '$btw',
     NOT = '$not',
+    ILIKE = '$ilike',
 }
 
 export function isOperator(value: unknown): value is FilterOperator {
@@ -85,6 +86,7 @@ export const OperatorSymbolToFunction = new Map<FilterOperator, (...args: any[])
     [FilterOperator.LTE, LessThanOrEqual],
     [FilterOperator.BTW, Between],
     [FilterOperator.NOT, Not],
+    [FilterOperator.ILIKE, ILike],
 ])
 
 export function getFilterTokens(raw: string): string[] {
@@ -144,6 +146,9 @@ function parseFilter<T>(query: PaginateQuery, config: PaginateConfig<T>) {
                         break
                     case FilterOperator.IN:
                         filter[column] = OperatorSymbolToFunction.get(op1)(value.split(','))
+                        break
+                    case FilterOperator.ILIKE:
+                        filter[column] = OperatorSymbolToFunction.get(op1)(`%${value}%`);
                         break
                     default:
                         filter[column] = OperatorSymbolToFunction.get(op1)(value)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -148,7 +148,7 @@ function parseFilter<T>(query: PaginateQuery, config: PaginateConfig<T>) {
                         filter[column] = OperatorSymbolToFunction.get(op1)(value.split(','))
                         break
                     case FilterOperator.ILIKE:
-                        filter[column] = OperatorSymbolToFunction.get(op1)(`%${value}%`);
+                        filter[column] = OperatorSymbolToFunction.get(op1)(`%${value}%`)
                         break
                     default:
                         filter[column] = OperatorSymbolToFunction.get(op1)(value)


### PR DESCRIPTION
Related to https://github.com/ppetzold/nestjs-paginate/issues/194

This PR aims to include the `$ilike` operator.

The main idea is to allow the ilike operator to any filter needed without using the _searchable_ column. 

![image](https://user-images.githubusercontent.com/6190599/199581679-a5fc59fa-5fce-4ca1-ba56-fc5d4f622ac7.png)

Added a new unit test for the ilike scenario: `should return result based on $ilike filter`

**Future work:** I am planning to create a new contribution to allow using `$ilike` operator with multiple options. (i.e: `$ilike:Active Und, Declined due, Any type of`).
