### PR TITLE
fix: update searchBy query to allow searchBy on other column types than text

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -298,23 +298,16 @@ export async function paginate<T extends ObjectLiteral>(
             new Brackets((qb: SelectQueryBuilder<T>) => {
                 for (const column of searchBy) {
                     const propertyPath = (column as string).split('.')
-                    if (propertyPath.length > 1) {
-                        const alias = queryBuilder.expressionMap.mainAlias.metadata.hasRelationWithPropertyPath(
-                            propertyPath[0]
-                        )
-                            ? `${qb.alias}_${column}`
-                            : `${qb.alias}.${column}`
-                        const condition: WherePredicateOperator = {
-                            operator: 'ilike',
-                            parameters: [alias, `:${column}`],
-                        }
-                        qb.orWhere(qb['createWhereConditionExpression'](condition), {
-                            [column]: `%${query.search}%`,
-                        })
+                    const hasRelation =
+                        propertyPath.length > 1 &&
+                        queryBuilder.expressionMap.mainAlias.metadata.hasRelationWithPropertyPath(propertyPath[0])
+
+                    const aliasColumn = hasRelation ? `${qb.alias}_${column}` : `${qb.alias}.${column}`
+
+                    if (['postgres', 'cockroachdb'].includes(queryBuilder.connection.options.type)) {
+                        qb.orWhere(`${aliasColumn}::text ILIKE '%${query.search}%'`)
                     } else {
-                        qb.orWhere({
-                            [column]: ILike(`%${query.search}%`),
-                        })
+                        qb.orWhere(`UPPER(${aliasColumn}) LIKE UPPER('%${query.search}%')`)
                     }
                 }
             })


### PR DESCRIPTION
Hey !
As discussed in #436 here is my try to fix the following issues: 
#436, #435, #366

The PR is split into two commits.


The tests are running through, but of course the tests are only for sqlite & so the coverage for postgres/coachrochdb is not given....

BR Jakob