### PR TITLE
feat: introduce starts with ($sw) operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pagination and filtering helper method for TypeORM repositories or query builder
 - Pagination conforms to [JSON:API](https://jsonapi.org/)
 - Sort by multiple columns
 - Search across columns
-- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`, `$ilike`)
+- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`, `$ilike`, `$sw`)
 - Include relations
 
 ## Installation
@@ -313,6 +313,8 @@ Filter operators must be whitelisted per column in `PaginateConfig`.
 `?filter.id=$not:$in:2,5,7` where column `id` is **not** `2`, `5` or `7`
 
 `?filter.summary=$not:$ilike:term` where column `summary` does **not** contain `term`
+
+`?filter.summary=$sw:term` where column `summary` starts with `term`
 
 `?filter.seenAt=$null` where column `seenAt` is `NULL`
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1236,17 +1236,40 @@ describe('paginate', () => {
         const query: PaginateQuery = {
             path: '',
             filter: {
-                name: '$ilike:Garf',
+                name: '$ilike:arf',
             },
         }
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.meta.filter).toStrictEqual({
-            name: '$ilike:Garf',
+            name: '$ilike:arf',
         })
         expect(result.data).toStrictEqual([cats[1]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$ilike:Garf')
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$ilike:arf')
+    })
+
+    it('should return result based on $sw filter', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            filterableColumns: {
+                name: [FilterOperator.SW],
+            },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: {
+                name: '$sw:Ga',
+            },
+        }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(result.meta.filter).toStrictEqual({
+            name: '$sw:Ga',
+        })
+        expect(result.data).toStrictEqual([cats[1]])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$sw:Ga')
     })
 
     it('should return result based on filter and search term', async () => {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -73,6 +73,7 @@ export enum FilterOperator {
     BTW = '$btw',
     NOT = '$not',
     ILIKE = '$ilike',
+    SW = '$sw',
 }
 
 export function isOperator(value: unknown): value is FilterOperator {
@@ -90,6 +91,7 @@ export const OperatorSymbolToFunction = new Map<FilterOperator, (...args: any[])
     [FilterOperator.BTW, Between],
     [FilterOperator.NOT, Not],
     [FilterOperator.ILIKE, ILike],
+    [FilterOperator.SW, ILike],
 ])
 
 export function getFilterTokens(raw: string): string[] {
@@ -157,6 +159,9 @@ function parseFilter<T>(query: PaginateQuery, config: PaginateConfig<T>) {
                         break
                     case FilterOperator.ILIKE:
                         filter[column] = OperatorSymbolToFunction.get(op1)(`%${value}%`)
+                        break
+                    case FilterOperator.SW:
+                        filter[column] = OperatorSymbolToFunction.get(op1)(`${value}%`)
                         break
                     default:
                         filter[column] = OperatorSymbolToFunction.get(op1)(value)


### PR DESCRIPTION
The `$ilike` operator as its currently implemented, introduces a wildcard automatically for the caller. The net effect is that the query cannot use indices.

This PR introduces a new "starts with" operator `$sw` which as the name implies provides the ability to search by prefix. This *can* make use of indices.