### PR TITLE
feat: implement auto EagerLoads in library

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ export class CatEntity {
   @Column('int')
   age: number
 
-  @OneToMany(t => LionKingEntity, lionKing.cats, {
+  @OneToMany(() => CatToyEntity, (catToy) => catToy.cat, {
     eager: true,
   })
-  lionKings: LionKingEntity[];
+  toys: CatToyEntity[]
 }
 
 // service
@@ -295,7 +295,8 @@ class CatService {
   public findAll(query: PaginateQuery): Promise<Paginated<CatEntity>> {
     return paginate(query, this.catsRepository, {
       sortableColumns: ['id', 'name', 'color', 'age'],
-    }) // automatically loads all eager relationships, disable setting property `loadEagerRelations` as false
+      loadEagerRelations: true // set this property as true to enable the eager loading
+    })
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -261,6 +261,45 @@ const paginateConfig: PaginateConfig<CatEntity> {
 }
 ```
 
+## Eager loading
+
+Eager loading should work with typeorm's eager property out the box. Like so
+
+```typescript
+import { Entity, OneToMany } from 'typeorm';
+
+@Entity()
+export class CatEntity {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column('text')
+  name: string
+
+  @Column('text')
+  color: string
+
+  @Column('int')
+  age: number
+
+  @OneToMany(t => LionKingEntity, lionKing.cats, {
+    eager: true,
+  })
+  lionKings: LionKingEntity[];
+}
+
+// service
+class CatService {
+  constructor(private readonly catsRepository: Repository<CatEntity>) {}
+
+  public findAll(query: PaginateQuery): Promise<Paginated<CatEntity>> {
+    return paginate(query, this.catsRepository, {
+      sortableColumns: ['id', 'name', 'color', 'age'],
+    }) // automatically loads all eager relationships, disable setting property `loadEagerRelations` as false
+  }
+}
+```
+
 ## Usage with Query Builder
 
 You can paginate custom queries by passing on the query builder:

--- a/src/__tests__/cat.entity.ts
+++ b/src/__tests__/cat.entity.ts
@@ -32,7 +32,9 @@ export class CatEntity {
     @Column(() => SizeEmbed)
     size: SizeEmbed
 
-    @OneToMany(() => CatToyEntity, (catToy) => catToy.cat)
+    @OneToMany(() => CatToyEntity, (catToy) => catToy.cat, {
+        eager: true,
+    })
     toys: CatToyEntity[]
 
     @OneToOne(() => CatHomeEntity, (catHome) => catHome.cat, { nullable: true })

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1981,4 +1981,24 @@ describe('paginate', () => {
 
         expect(result.data.length).toBe(4)
     })
+
+    it('should return eager relations when set the property `loadEagerRelations` as true', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            defaultSortBy: [['id', 'ASC']],
+            loadEagerRelations: true,
+            searchableColumns: ['name'],
+        }
+
+        const query: PaginateQuery = {
+            path: '',
+            search: 'Garfield'
+        }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(result.data[0].toys).toBeDefined()
+
+        expect(result.data[0].toys).toHaveLength(1)
+    })
 })

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1992,7 +1992,7 @@ describe('paginate', () => {
 
         const query: PaginateQuery = {
             path: '',
-            search: 'Garfield'
+            search: 'Garfield',
         }
 
         const result = await paginate<CatEntity>(query, catRepo, config)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -5,6 +5,7 @@ import {
     FindOptionsWhere,
     FindOptionsRelations,
     ObjectLiteral,
+    FindOptionsUtils,
 } from 'typeorm'
 import { PaginateQuery } from './decorator'
 import { ServiceUnavailableException, Logger } from '@nestjs/common'
@@ -62,6 +63,7 @@ export interface PaginateConfig<T> {
     filterableColumns?: {
         [key in Column<T>]?: (FilterOperator | FilterSuffix)[]
     }
+    loadEagerRelations?: boolean
     withDeleted?: boolean
     relativePath?: boolean
     origin?: string
@@ -145,6 +147,12 @@ export async function paginate<T extends ObjectLiteral>(
     let [items, totalItems]: [T[], number] = [[], 0]
 
     const queryBuilder = repo instanceof Repository ? repo.createQueryBuilder('__root') : repo
+
+    if (repo instanceof Repository && !config.relations && (config.loadEagerRelations === undefined || config.loadEagerRelations === true)) {
+        if (!config.relations) {
+            FindOptionsUtils.joinEagerRelations(queryBuilder, queryBuilder.alias, repo.metadata);
+        }
+    }
 
     if (isPaginated) {
         // Switch from take and skip to limit and offset
@@ -274,12 +282,12 @@ export async function paginate<T extends ObjectLiteral>(
 
     const filterQuery = query.filter
         ? '&' +
-          stringify(
-              mapKeys(query.filter, (_param, name) => 'filter.' + name),
-              '&',
-              '=',
-              { encodeURIComponent: (str) => str }
-          )
+        stringify(
+            mapKeys(query.filter, (_param, name) => 'filter.' + name),
+            '&',
+            '=',
+            { encodeURIComponent: (str) => str }
+        )
         : ''
 
     const options = `&limit=${limit}${sortByQuery}${searchQuery}${searchByQuery}${filterQuery}`

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -150,7 +150,7 @@ export async function paginate<T extends ObjectLiteral>(
 
     if (repo instanceof Repository && !config.relations && config.loadEagerRelations === true) {
         if (!config.relations) {
-            FindOptionsUtils.joinEagerRelations(queryBuilder, queryBuilder.alias, repo.metadata);
+            FindOptionsUtils.joinEagerRelations(queryBuilder, queryBuilder.alias, repo.metadata)
         }
     }
 
@@ -282,12 +282,12 @@ export async function paginate<T extends ObjectLiteral>(
 
     const filterQuery = query.filter
         ? '&' +
-        stringify(
-            mapKeys(query.filter, (_param, name) => 'filter.' + name),
-            '&',
-            '=',
-            { encodeURIComponent: (str) => str }
-        )
+          stringify(
+              mapKeys(query.filter, (_param, name) => 'filter.' + name),
+              '&',
+              '=',
+              { encodeURIComponent: (str) => str }
+          )
         : ''
 
     const options = `&limit=${limit}${sortByQuery}${searchQuery}${searchByQuery}${filterQuery}`

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -148,7 +148,7 @@ export async function paginate<T extends ObjectLiteral>(
 
     const queryBuilder = repo instanceof Repository ? repo.createQueryBuilder('__root') : repo
 
-    if (repo instanceof Repository && !config.relations && (config.loadEagerRelations === undefined || config.loadEagerRelations === true)) {
+    if (repo instanceof Repository && !config.relations && config.loadEagerRelations === true) {
         if (!config.relations) {
             FindOptionsUtils.joinEagerRelations(queryBuilder, queryBuilder.alias, repo.metadata);
         }


### PR DESCRIPTION
# User Stories
As an developer, i want to fetch eager relationships automatically when querying using repos, so the `nestjs-paginate` behavior will get similar to typeorm default behavior

# Description
Sometimes we need to get nested relationships for nested entities, so, create a strategy to handle eager loads can help developers to increase their productivity

# Proposed Changes
- create the configuration field `loadEagerRelations` as opitional
- when set `loadEagerRelations` auto load all eager relations and nested eager relations
- implement the tests suites

# Checklist
- [x] Tests
- [x] Documentation