### PR TITLE
Allow user to choose between limit/offset and take/skip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,14 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * Description: Overrides the origin of absolute resource links if set.
    */
   origin: 'http://cats.example',
+
+  /**
+   * Required: false
+   * Type: string
+   * Description: Allow user to choose between limit/offset and take/skip.
+   * Default: PaginationTypeEnum.TAKE_AND_SKIP
+   */
+  paginationType: PaginationTypeEnum.LIMIT_AND_OFFSET,
 }
 ```
 
@@ -342,6 +350,29 @@ const config: PaginateConfig<CatEntity> = {
 
 const result = await paginate<CatEntity>(query, catRepo, config)
 ```
+
+## Usage of pagination type
+
+You can use either `limit`/`offset` or `take`/`skip` to return paginated results.
+
+### Example
+
+#### Code
+
+```typescript
+const config: PaginateConfig<CatEntity> = {
+  paginationType: PaginationTypeEnum.LIMIT_AND_OFFSET,
+  // Or
+  paginationType: PaginationTypeEnum.TAKE_AND_SKIP,
+}
+
+const result = await paginate<CatEntity>(query, catRepo, config)
+```
+
+> However, using `limit`/`offset` can return unexpected results.   
+> For more information
+> see [#477](https://github.com/ppetzold/nestjs-paginate/issues/477), [#4742](https://github.com/typeorm/typeorm/issues/4742)
+> and [#5670](https://github.com/typeorm/typeorm/issues/5670).
 
 ## Single Filters
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * Required: false
    * Type: string
    * Description: Allow user to choose between limit/offset and take/skip.
-   * Default: PaginationTypeEnum.TAKE_AND_SKIP
+   * Default: PaginationType.TAKE_AND_SKIP
    */
-  paginationType: PaginationTypeEnum.LIMIT_AND_OFFSET,
+  paginationType: PaginationType.LIMIT_AND_OFFSET,
 }
 ```
 
@@ -361,9 +361,9 @@ You can use either `limit`/`offset` or `take`/`skip` to return paginated results
 
 ```typescript
 const config: PaginateConfig<CatEntity> = {
-  paginationType: PaginationTypeEnum.LIMIT_AND_OFFSET,
+  paginationType: PaginationType.LIMIT_AND_OFFSET,
   // Or
-  paginationType: PaginationTypeEnum.TAKE_AND_SKIP,
+  paginationType: PaginationType.TAKE_AND_SKIP,
 }
 
 const result = await paginate<CatEntity>(query, catRepo, config)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -52,7 +52,7 @@ export class Paginated<T> {
     }
 }
 
-export enum PaginationTypeEnum {
+export enum PaginationType {
     LIMIT_AND_OFFSET = 'limit',
     TAKE_AND_SKIP = 'take',
 }
@@ -74,13 +74,13 @@ export interface PaginateConfig<T> {
     withDeleted?: boolean
     relativePath?: boolean
     origin?: string
-    paginationType?: PaginationTypeEnum
+    paginationType?: PaginationType
 }
 
 export const DEFAULT_MAX_LIMIT = 100
 export const DEFAULT_LIMIT = 20
 export const NO_PAGINATION = 0
-export const DEFAULT_PAGINATE_TYPE = PaginationTypeEnum.TAKE_AND_SKIP
+export const DEFAULT_PAGINATE_TYPE = PaginationType.TAKE_AND_SKIP
 
 export async function paginate<T extends ObjectLiteral>(
     query: PaginateQuery,
@@ -169,7 +169,7 @@ export async function paginate<T extends ObjectLiteral>(
         // due to this problem https://github.com/typeorm/typeorm/issues/5670
         // (anyway this creates more clean query without double distinct)
         // queryBuilder.limit(limit).offset((page - 1) * limit)
-        if (paginationType === PaginationTypeEnum.LIMIT_AND_OFFSET) {
+        if (paginationType === PaginationType.LIMIT_AND_OFFSET) {
             queryBuilder.limit(limit).offset((page - 1) * limit)
         } else {
             queryBuilder.take(limit).skip((page - 1) * limit)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -52,6 +52,11 @@ export class Paginated<T> {
     }
 }
 
+export enum PaginationTypeEnum {
+    LIMIT_AND_OFFSET = 'limit',
+    TAKE_AND_SKIP = 'take',
+}
+
 export interface PaginateConfig<T> {
     relations?: FindOptionsRelations<T> | RelationColumn<T>[]
     sortableColumns: Column<T>[]
@@ -69,11 +74,13 @@ export interface PaginateConfig<T> {
     withDeleted?: boolean
     relativePath?: boolean
     origin?: string
+    paginationType?: PaginationTypeEnum
 }
 
 export const DEFAULT_MAX_LIMIT = 100
 export const DEFAULT_LIMIT = 20
 export const NO_PAGINATION = 0
+export const DEFAULT_PAGINATE_TYPE = PaginationTypeEnum.TAKE_AND_SKIP
 
 export async function paginate<T extends ObjectLiteral>(
     query: PaginateQuery,
@@ -85,6 +92,7 @@ export async function paginate<T extends ObjectLiteral>(
     const defaultLimit = config.defaultLimit || DEFAULT_LIMIT
     const maxLimit = positiveNumberOrDefault(config.maxLimit, DEFAULT_MAX_LIMIT)
     const queryLimit = positiveNumberOrDefault(query.limit, defaultLimit)
+    const paginationType = config.paginationType || DEFAULT_PAGINATE_TYPE
 
     const isPaginated = !(queryLimit === NO_PAGINATION && maxLimit === NO_PAGINATION)
 
@@ -159,9 +167,13 @@ export async function paginate<T extends ObjectLiteral>(
     if (isPaginated) {
         // Switch from take and skip to limit and offset
         // due to this problem https://github.com/typeorm/typeorm/issues/5670
-        // (anyway this creates more clean query without double dinstict)
+        // (anyway this creates more clean query without double distinct)
         // queryBuilder.limit(limit).offset((page - 1) * limit)
-        queryBuilder.take(limit).skip((page - 1) * limit)
+        if (paginationType === PaginationTypeEnum.LIMIT_AND_OFFSET) {
+            queryBuilder.limit(limit).offset((page - 1) * limit)
+        } else {
+            queryBuilder.take(limit).skip((page - 1) * limit)
+        }
     }
 
     if (config.relations) {


### PR DESCRIPTION
Leave the user the choice to choose between limit/offset and take/skip.
By doing so this avoid user to create a custom queryBuilder to pass to `paginate` function.

> Related to issue: https://github.com/typeorm/typeorm/issues/5670