### PR TITLE
Added prepare script for installation from repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "prebuild": "rimraf lib",
     "build": "tsc",
+    "prepare": "tsc",
     "dev:yalc": "nodemon --watch src --ext ts --exec 'npm run build && yalc push'",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:ci": "prettier --list-different \"src/**/*.ts\"",


### PR DESCRIPTION
With `"prepare": "tsc"` (or `"prepare": "npm run build"`) we can use `npm install` directly on a fork.