### PR TITLE
feat: contains operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pagination and filtering helper method for TypeORM repositories or query builder
 - Sort by multiple columns
 - Search across columns
 - Select columns
-- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`, `$ilike`, `$sw`)
+- Filter using operators (`$eq`, `$not`, `$null`, `$in`, `$gt`, `$gte`, `$lt`, `$lte`, `$btw`, `$ilike`, `$sw`, `$contains`)
 - Include relations and nested relations
 - Virtual column support
 
@@ -405,6 +405,8 @@ Filter operators must be whitelisted per column in `PaginateConfig`.
 `?filter.seenAt=$not:$null` where column `seenAt` is **not** `NULL`
 
 `?filter.createdAt=$btw:2022-02-02,2022-02-10` where column `createdAt` is between the dates `2022-02-02` and `2022-02-10`
+
+`?filter.roles=$contains:Moderator` where column `roles` is an array and contains the value "Moderator".
 
 ## Multi Filters
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ Filter operators must be whitelisted per column in `PaginateConfig`.
 
 `?filter.roles=$contains:Moderator` where column `roles` is an array and contains the value "Moderator".
 
+`?filter.roles=$contains:Moderator,Admin` where column `roles` is an array and contains the values "Moderator" and "Admin".
+
 ## Multi Filters
 
 Multi filters are filters that can be applied to a single column with a comparator. As for single filters, multi filters must be whitelisted per column in `PaginateConfig`.

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -267,6 +267,7 @@ export function parseFilter(
                     params.findOperator = OperatorSymbolToFunction.get(token.operator)(...token.value.split(','))
                     break
                 case FilterOperator.IN:
+                case FilterOperator.CONTAINS: // <- IN and CONTAINS are identically handled.
                     params.findOperator = OperatorSymbolToFunction.get(token.operator)(token.value.split(','))
                     break
                 case FilterOperator.ILIKE:

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,6 @@
 import { values } from 'lodash'
 import {
-    ArrayIncludes,
+    ArrayContains,
     Between,
     Brackets,
     Equal,
@@ -36,7 +36,7 @@ export enum FilterOperator {
     BTW = '$btw',
     ILIKE = '$ilike',
     SW = '$sw',
-    CONTAINS = "$contains",
+    CONTAINS = '$contains',
 }
 
 export function isOperator(value: unknown): value is FilterOperator {
@@ -75,7 +75,7 @@ export const OperatorSymbolToFunction = new Map<
     [FilterOperator.ILIKE, ILike],
     [FilterSuffix.NOT, Not],
     [FilterOperator.SW, ILike],
-    [FilterOperator.CONTAINS, ArrayIncludes]
+    [FilterOperator.CONTAINS, ArrayContains],
 ])
 
 type Filter = { comparator: FilterComparator; findOperator: FindOperator<string> }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,16 +1,17 @@
 import { values } from 'lodash'
 import {
+    ArrayIncludes,
+    Between,
     Brackets,
     Equal,
     FindOperator,
+    ILike,
     In,
-    MoreThan,
-    MoreThanOrEqual,
     IsNull,
     LessThan,
     LessThanOrEqual,
-    Between,
-    ILike,
+    MoreThan,
+    MoreThanOrEqual,
     Not,
     SelectQueryBuilder,
 } from 'typeorm'
@@ -35,6 +36,7 @@ export enum FilterOperator {
     BTW = '$btw',
     ILIKE = '$ilike',
     SW = '$sw',
+    CONTAINS = "$contains",
 }
 
 export function isOperator(value: unknown): value is FilterOperator {
@@ -73,6 +75,7 @@ export const OperatorSymbolToFunction = new Map<
     [FilterOperator.ILIKE, ILike],
     [FilterSuffix.NOT, Not],
     [FilterOperator.SW, ILike],
+    [FilterOperator.CONTAINS, ArrayIncludes]
 ])
 
 type Filter = { comparator: FilterComparator; findOperator: FindOperator<string> }


### PR DESCRIPTION
Closes #534

This PR adds the contains operator to the list of operators. This corresponds to `ArrayIncludes`.

Perhaps the name `contains` is incorrect? maybe `includes` or something similar would be better. Open to feedback.