### PR TITLE
Add `_rel` suffix to relationship columns to avoid duplicate columns

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -137,9 +137,14 @@ export function fixColumnAlias(
 ): string {
     if (isRelation) {
         if (isVirtualProperty && query) {
-            return `(${query(`${alias}_${properties.propertyPath}`)})` // () is needed to avoid parameter conflict
+            return `(${query(`${alias}_${properties.propertyPath}_rel`)})` // () is needed to avoid parameter conflict
         } else if ((isVirtualProperty && !query) || properties.isNested) {
-            return `${alias}_${properties.propertyPath}_rel_${properties.propertyName}`
+            if (properties.propertyName.includes(".")) {
+                const [nestedRel, nestedCol] = properties.propertyName.split(".")
+                return `${alias}_${properties.propertyPath}_rel_${nestedRel}_rel.${nestedCol}`
+            } else {
+                return `${alias}_${properties.propertyPath}_rel_${properties.propertyName}`
+            }
         } else {
             return `${alias}_${properties.propertyPath}_rel.${properties.propertyName}`
         }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -139,9 +139,9 @@ export function fixColumnAlias(
         if (isVirtualProperty && query) {
             return `(${query(`${alias}_${properties.propertyPath}`)})` // () is needed to avoid parameter conflict
         } else if ((isVirtualProperty && !query) || properties.isNested) {
-            return `${alias}_${properties.propertyPath}_${properties.propertyName}`
+            return `${alias}_${properties.propertyPath}_rel_${properties.propertyName}`
         } else {
-            return `${alias}_${properties.propertyPath}.${properties.propertyName}`
+            return `${alias}_${properties.propertyPath}_rel.${properties.propertyName}`
         }
     } else if (isVirtualProperty) {
         return query ? `(${query(`${alias}`)})` : `${alias}_${properties.propertyName}`

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -139,8 +139,8 @@ export function fixColumnAlias(
         if (isVirtualProperty && query) {
             return `(${query(`${alias}_${properties.propertyPath}_rel`)})` // () is needed to avoid parameter conflict
         } else if ((isVirtualProperty && !query) || properties.isNested) {
-            if (properties.propertyName.includes(".")) {
-                const [nestedRel, nestedCol] = properties.propertyName.split(".")
+            if (properties.propertyName.includes('.')) {
+                const [nestedRel, nestedCol] = properties.propertyName.split('.')
                 return `${alias}_${properties.propertyPath}_rel_${nestedRel}_rel.${nestedCol}`
             } else {
                 return `${alias}_${properties.propertyPath}_rel_${properties.propertyName}`

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -46,7 +46,7 @@ describe('paginate', () => {
                       database: ':memory:',
                   }),
             synchronize: true,
-            logging: false,
+            logging: ['error'],
             entities: [CatEntity, CatToyEntity, CatHomeEntity, CatHomePillowEntity],
         })
         await dataSource.initialize()

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -126,7 +126,10 @@ export async function paginate<T extends ObjectLiteral>(
         // relations: ["relation"]
         if (Array.isArray(config.relations)) {
             config.relations.forEach((relation) => {
-                queryBuilder.leftJoinAndSelect(`${queryBuilder.alias}.${relation}`, `${queryBuilder.alias}_${relation}`)
+                queryBuilder.leftJoinAndSelect(
+                    `${queryBuilder.alias}.${relation}`,
+                    `${queryBuilder.alias}_${relation}_rel`
+                )
             })
         } else {
             // relations: {relation:true}

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -144,11 +144,11 @@ export async function paginate<T extends ObjectLiteral>(
 
                     queryBuilder.leftJoinAndSelect(
                         `${alias ?? prefix}.${relationName}`,
-                        `${alias ?? prefix}_${relationName}`
+                        `${alias ?? prefix}_${relationName}_rel`
                     )
 
                     if (typeof relationSchema === 'object') {
-                        createQueryBuilderRelations(relationName, relationSchema, `${alias ?? prefix}_${relationName}`)
+                        createQueryBuilderRelations(relationName, relationSchema, `${alias ?? prefix}_${relationName}_rel`)
                     }
                 })
             }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -264,7 +264,7 @@ export async function paginate<T extends ObjectLiteral>(
     }
 
     if (isPaginated) {
-        ;[items, totalItems] = await queryBuilder.getManyAndCount()
+        [items, totalItems] = await queryBuilder.getManyAndCount()
     } else {
         items = await queryBuilder.getMany()
     }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -148,7 +148,11 @@ export async function paginate<T extends ObjectLiteral>(
                     )
 
                     if (typeof relationSchema === 'object') {
-                        createQueryBuilderRelations(relationName, relationSchema, `${alias ?? prefix}_${relationName}_rel`)
+                        createQueryBuilderRelations(
+                            relationName,
+                            relationSchema,
+                            `${alias ?? prefix}_${relationName}_rel`
+                        )
                     }
                 })
             }
@@ -264,7 +268,7 @@ export async function paginate<T extends ObjectLiteral>(
     }
 
     if (isPaginated) {
-        [items, totalItems] = await queryBuilder.getManyAndCount()
+        ;[items, totalItems] = await queryBuilder.getManyAndCount()
     } else {
         items = await queryBuilder.getMany()
     }


### PR DESCRIPTION
This PR attempts to address #518 by introducing a `_rel` suffix to all relationship aliases so that `parent.relationship.id` doesn't conflict with `parent.relationship_id` (a common occurence with TypeORM's default naming strategy).

I do not have enough understanding of the entire codebase to be confident that this is the optimal solution, but it shows a solution, which you should feel free to improve upon. I drafted this against the test suite, which are all passing, except for 1. Appearantly my solution makes it so that a virtual column filter is now selected in the resulting items, which was not the case before, this should be fixed but I don't know where this happens.

Also, the test suite should be extended to cover MySQL, if you draft up how you would like to extend the current 2-driver (SQLite & PostGres) setup to a generic n-driver setup, I can fix all the failing MySQL tests for you.

Let me know what you think!