### PR TITLE
feat: Support dot notation syntax for nested relations

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -710,9 +710,42 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Garfield')
     })
 
-    it('should load nested relations', async () => {
+    it('should load nested relations (object notation)', async () => {
         const config: PaginateConfig<CatEntity> = {
             relations: { home: { pillows: true } },
+            sortableColumns: ['id', 'name'],
+            searchableColumns: ['name'],
+        }
+        const query: PaginateQuery = {
+            path: '',
+            search: 'Garfield',
+        }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        const cat = clone(cats[1])
+        const catHomesClone = clone(catHomes[1])
+        const catHomePillowsClone3 = clone(catHomePillows[3])
+        delete catHomePillowsClone3.home
+        const catHomePillowsClone4 = clone(catHomePillows[4])
+        delete catHomePillowsClone4.home
+        const catHomePillowsClone5 = clone(catHomePillows[5])
+        delete catHomePillowsClone5.home
+
+        catHomesClone.countCat = cats.filter((cat) => cat.id === catHomesClone.cat.id).length
+        catHomesClone.pillows = [catHomePillowsClone3, catHomePillowsClone4, catHomePillowsClone5]
+        cat.home = catHomesClone
+        delete cat.home.cat
+
+        expect(result.meta.search).toStrictEqual('Garfield')
+        expect(result.data).toStrictEqual([cat])
+        expect(result.data[0].home).toBeDefined()
+        expect(result.data[0].home.pillows).toStrictEqual(cat.home.pillows)
+    })
+
+    it('should load nested relations (array notation)', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            relations: ['home.pillows'],
             sortableColumns: ['id', 'name'],
             searchableColumns: ['name'],
         }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -138,17 +138,13 @@ export async function paginate<T extends ObjectLiteral>(
 
                 queryBuilder.leftJoinAndSelect(
                     `${alias ?? prefix}.${relationName}`,
-                        `${alias ?? prefix}_${relationName}_rel`
-                    )
+                    `${alias ?? prefix}_${relationName}_rel`
+                )
 
-                    if (typeof relationSchema === 'object') {
-                        createQueryBuilderRelations(
-                            relationName,
-                            relationSchema,
-                            `${alias ?? prefix}_${relationName}_rel`
-                        )
-                    }
-                })
+                if (typeof relationSchema === 'object') {
+                    createQueryBuilderRelations(relationName, relationSchema, `${alias ?? prefix}_${relationName}_rel`)
+                }
+            })
         }
         createQueryBuilderRelations(queryBuilder.alias, relations)
     }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -6,6 +6,7 @@ import {
     FindOptionsRelations,
     ObjectLiteral,
     FindOptionsUtils,
+    FindOptionsRelationByString,
 } from 'typeorm'
 import { PaginateQuery } from './decorator'
 import { ServiceUnavailableException, Logger } from '@nestjs/common'
@@ -62,7 +63,7 @@ export enum PaginationType {
 }
 
 export interface PaginateConfig<T> {
-    relations?: FindOptionsRelations<T> | RelationColumn<T>[]
+    relations?: FindOptionsRelations<T> | RelationColumn<T>[] | FindOptionsRelationByString
     sortableColumns: Column<T>[]
     nullSort?: 'first' | 'last'
     searchableColumns?: Column<T>[]


### PR DESCRIPTION
The `PaginateConfig.relations` field can now be given as `string[]` too:

```
{
  relations: ["cat", "cat.home", "cat.home.pillow"]
}
```

should I mention it in the docs anywhere, or shall we take satisfaction knowing that people won't bump into #738 anymore? :)

closes #738 