### PR TITLE
fix: implemented a proper mechanism for using where condition in options

### DIFF
--- a/src/__tests__/cat-toy.entity.ts
+++ b/src/__tests__/cat-toy.entity.ts
@@ -1,6 +1,7 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { CatEntity } from './cat.entity'
 import { SizeEmbed } from './size.embed'
+import { ToyShopEntity } from './toy-shop.entity'
 
 @Entity()
 export class CatToyEntity {
@@ -12,6 +13,10 @@ export class CatToyEntity {
 
     @Column(() => SizeEmbed)
     size: SizeEmbed
+
+    @ManyToOne(() => ToyShopEntity, { nullable: true })
+    @JoinColumn()
+    shop?: ToyShopEntity
 
     @ManyToOne(() => CatEntity, (cat) => cat.toys)
     @JoinColumn()

--- a/src/__tests__/toy-shop-address.entity.ts
+++ b/src/__tests__/toy-shop-address.entity.ts
@@ -1,0 +1,13 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity()
+export class ToyShopAddressEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    address: string
+
+    @CreateDateColumn()
+    createdAt: string
+}

--- a/src/__tests__/toy-shop.entity.ts
+++ b/src/__tests__/toy-shop.entity.ts
@@ -1,0 +1,18 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { ToyShopAddressEntity } from './toy-shop-address.entity'
+
+@Entity()
+export class ToyShopEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    shopName: string
+
+    @OneToOne(() => ToyShopAddressEntity, { nullable: true })
+    @JoinColumn()
+    address: ToyShopAddressEntity
+
+    @CreateDateColumn()
+    createdAt: string
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -140,8 +140,14 @@ export function fixColumnAlias(
             return `(${query(`${alias}_${properties.propertyPath}_rel`)})` // () is needed to avoid parameter conflict
         } else if ((isVirtualProperty && !query) || properties.isNested) {
             if (properties.propertyName.includes('.')) {
-                const [nestedRel, nestedCol] = properties.propertyName.split('.')
-                return `${alias}_${properties.propertyPath}_rel_${nestedRel}_rel.${nestedCol}`
+                const propertyPath = properties.propertyName.split('.')
+                const nestedRelations = propertyPath
+                    .slice(0, -1)
+                    .map((v) => `${v}_rel`)
+                    .join('_')
+                const nestedCol = propertyPath[propertyPath.length - 1]
+
+                return `${alias}_${properties.propertyPath}_rel_${nestedRelations}.${nestedCol}`
             } else {
                 return `${alias}_${properties.propertyPath}_rel_${properties.propertyName}`
             }


### PR DESCRIPTION
It wasn't easy, or at least I didn't find an easy way, I found one internal method in Typeorm repos, that does the transform, the main problem was with aliases, we are using a custom mechanism for it here, not sure is it right or no, but changing it will be a bigger hassle than remap Typeform ones 

fix for this one https://github.com/ppetzold/nestjs-paginate/issues/750
and I saw another similar issue  