### PR TITLE
feat: Add config options to ignore `select` and `searchBy` query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,22 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * Description: Overrides the origin of absolute resource links if set.
    */
   origin: 'http://cats.example',
+
+  /**
+   * Required: false
+   * Type: boolean
+   * Default: false
+   * Description: Prevent `searchBy` query param from limiting search scope further. Search will depend upon `searchableColumns` config option only
+   */
+  ignoreSearchByInQueryParam: true,
+
+  /**
+   * Required: false
+   * Type: boolean
+   * Default: false
+   * Description: Prevent `select` query param from limiting selection further. Partial selection will depend upon `select` config option only
+   */
+  ignoreSelectInQueryParam: true,
 }
 ```
 
@@ -465,7 +481,6 @@ You can use two default decorators @ApiOkResponsePaginated and @ApiPagination to
 `@ApiOkPaginatedResponse` is for response body, return http[](https://) status is 200
 
 `@ApiPaginationQuery` is for query params
-
 
 ```typescript
   @Get()

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -2485,6 +2485,111 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.id=$not:$in:1,2,5')
     })
 
+    it('should use searchBy in query param when ignoreSearchByInQueryParam is not defined', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            searchableColumns: ['name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            search: "Milo",
+            searchBy: ['color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data.length).toEqual(0)
+        expect(result.meta.searchBy).toStrictEqual(['color'])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo&searchBy=color')
+    })
+
+    it('should use searchBy in query param when ignoreSearchByInQueryParam is set to false', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            ignoreSearchByInQueryParam: false,
+            searchableColumns: ['name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            search: "Milo",
+            searchBy: ['color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data.length).toEqual(0)
+        expect(result.meta.searchBy).toStrictEqual(['color'])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo&searchBy=color')
+    })
+
+    it('should ignore searchBy in query param when ignoreSearchByInQueryParam is set to true', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            ignoreSearchByInQueryParam: true,
+            searchableColumns: ['name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            search: "Milo",
+            searchBy: ['color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data.length).toEqual(1)
+        expect(result.data).toStrictEqual([cats[0]])
+        expect(result.meta.searchBy).toStrictEqual(['name', 'color'])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo')
+    })
+
+    it('should use select in query param when ignoreSelectInQueryParam is not defined', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            select: ['id', 'name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            select: ['id', 'color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data[0]).toEqual({id: cats[0].id, color: cats[0].color})
+        expect(result.meta.select).toStrictEqual(['id', 'color'])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,color')
+    })
+
+    it('should use select in query param when ignoreSelectInQueryParam is set to false', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            ignoreSelectInQueryParam: false,
+            select: ['id', 'name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            select: ['id', 'color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data[0]).toEqual({id: cats[0].id, color: cats[0].color})
+        expect(result.meta.select).toStrictEqual(['id', 'color'])
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,color')
+    })
+
+    it('should ignore select in query param when ignoreSelectInQueryParam is set to true', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            ignoreSelectInQueryParam: true,
+            select: ['id', 'name', 'color']
+        }
+        const query: PaginateQuery = {
+            path: '',
+            select: ['id', 'color']
+        }
+        
+        const result = await paginate<CatEntity>(query, catRepo, config)
+        expect(result.data[0]).toEqual({id: cats[0].id, color: cats[0].color, name: cats[0].name})
+        expect(result.meta.select).toEqual(undefined)
+        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+    })
+
+
     describe('should return result based on date column filter', () => {
         it('with $not and $null operators', async () => {
             const config: PaginateConfig<CatEntity> = {


### PR DESCRIPTION
New config options are now available `ignoreSearchByInQueryParam` and `ignoreSelectInQueryParam`.

This implements #773 