### PR TITLE
feat: Add `sortBy` columns to swagger

### DIFF
--- a/src/swagger/api-paginated-query.decorator.ts
+++ b/src/swagger/api-paginated-query.decorator.ts
@@ -21,8 +21,8 @@ export function SortBy(paginationConfig: PaginateConfig<any>) {
         : 'No default sorting specified, the result order is not guaranteed'
 
     const sortBy = paginationConfig.sortableColumns.reduce((prev, curr) => {
-        return [...prev, `${curr}:ASC`, `${curr}:DESC`];
-    }, []);
+        return [...prev, `${curr}:ASC`, `${curr}:DESC`]
+    }, [])
 
     return ApiQuery({
         name: 'sortBy',

--- a/src/swagger/api-paginated-query.decorator.ts
+++ b/src/swagger/api-paginated-query.decorator.ts
@@ -20,9 +20,14 @@ export function SortBy(paginationConfig: PaginateConfig<any>) {
         ? paginationConfig.defaultSortBy.map(([col, order]) => `${col}:${order}`).join(',')
         : 'No default sorting specified, the result order is not guaranteed'
 
+    const sortBy = paginationConfig.sortableColumns.reduce((prev, curr) => {
+        return [...prev, `${curr}:ASC`, `${curr}:DESC`];
+    }, []);
+
     return ApiQuery({
         name: 'sortBy',
         isArray: true,
+        enum: sortBy,
         description: `Parameter to sort by.
       <p>To sort by multiple fields, just provide query param multiple types. The order in url defines an order of sorting</p>
       ${p('Format', 'fieldName:DIRECTION')}

--- a/src/swagger/pagination-docs.spec.ts
+++ b/src/swagger/pagination-docs.spec.ts
@@ -97,6 +97,7 @@ describe('PaginatedEndpoint decorator', () => {
                     type: 'array',
                     items: {
                         type: 'string',
+                        enum: ['id:ASC', 'id:DESC'],
                     },
                 },
             },
@@ -204,6 +205,7 @@ describe('PaginatedEndpoint decorator', () => {
                     type: 'array',
                     items: {
                         type: 'string',
+                        enum: ['id:ASC', 'id:DESC'],
                     },
                 },
             },


### PR DESCRIPTION
This includes `sortableColumns` from `paginationConfig` in swagger config. It's useful for generating sortable columns in frontend. 