### PR TITLE
Fix TypeError When Using @Paginate() with @MessagePattern() (@nestjs/microservices)

### DIFF
--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -1,5 +1,5 @@
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants'
-import { HttpArgumentsHost, CustomParamFactory, ExecutionContext, ContextType } from '@nestjs/common/interfaces'
+import { CustomParamFactory, ExecutionContext, HttpArgumentsHost } from '@nestjs/common/interfaces'
 import { Request as ExpressRequest } from 'express'
 import { FastifyRequest } from 'fastify'
 import { Paginate, PaginateQuery } from './decorator'

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -1,5 +1,5 @@
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants'
-import { HttpArgumentsHost, CustomParamFactory, ExecutionContext } from '@nestjs/common/interfaces'
+import { HttpArgumentsHost, CustomParamFactory, ExecutionContext, ContextType } from '@nestjs/common/interfaces'
 import { Request as ExpressRequest } from 'express'
 import { FastifyRequest } from 'fastify'
 import { Paginate, PaginateQuery } from './decorator'
@@ -18,6 +18,7 @@ const decoratorfactory = getParamDecoratorFactory<PaginateQuery>(Paginate)
 
 function expressContextFactory(query: ExpressRequest['query']): Partial<ExecutionContext> {
     const mockContext: Partial<ExecutionContext> = {
+        getType: <ContextType>() => 'http' as ContextType,
         switchToHttp: (): HttpArgumentsHost =>
             Object({
                 getRequest: (): Partial<ExpressRequest> =>
@@ -34,6 +35,7 @@ function expressContextFactory(query: ExpressRequest['query']): Partial<Executio
 
 function fastifyContextFactory(query: FastifyRequest['query']): Partial<ExecutionContext> {
     const mockContext: Partial<ExecutionContext> = {
+        getType: <ContextType>() => 'http' as ContextType,
         switchToHttp: (): HttpArgumentsHost =>
             Object({
                 getRequest: (): Partial<FastifyRequest> =>

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -51,7 +51,7 @@ function parseParam<T>(queryParam: unknown, parserLogic: (param: string, res: an
 
 export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionContext): PaginateQuery => {
     const request: ExpressRequest | FastifyRequest = ctx.switchToHttp().getRequest()
-    const query = request.query as Record<string, unknown>
+    const query = (ctx.contextType === 'rpc' ? request : request.query) as Record<string, unknown>
 
     // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
     let originalUrl: string

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import type { Request as ExpressRequest } from 'express'
+import type { FastifyRequest } from 'fastify'
 import { Dictionary, isString, mapKeys, pickBy } from 'lodash'
-import { FastifyRequest } from 'fastify'
 
 function isRecord(data: unknown): data is Record<string, unknown> {
     return data !== null && typeof data === 'object' && !Array.isArray(data)

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import type { Request as ExpressRequest } from 'express'
-import type { FastifyRequest } from 'fastify'
 import { pickBy, Dictionary, isString, mapKeys } from 'lodash'
+import { FastifyRequest } from 'fastify'
 
 function isRecord(data: unknown): data is Record<string, unknown> {
     return data !== null && typeof data === 'object' && !Array.isArray(data)
@@ -55,7 +55,7 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
 
     switch (ctx.getType()) {
         case 'http':
-            const request = ctx.switchToHttp().getRequest()
+            const request: ExpressRequest | FastifyRequest = ctx.switchToHttp().getRequest()
 
             // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
             let originalUrl: string

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -50,8 +50,9 @@ function parseParam<T>(queryParam: unknown, parserLogic: (param: string, res: an
 }
 
 export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionContext): PaginateQuery => {
+    const isRpc = (ctx as ExecutionContext & { contextType: string })?.contextType === 'rpc'
     const request: ExpressRequest | FastifyRequest = ctx.switchToHttp().getRequest()
-    const query = (ctx.contextType === 'rpc' ? request : request.query) as Record<string, unknown>
+    const query = (isRpc ? request : request.query) as Record<string, unknown>
 
     // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
     let originalUrl: string

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import type { Request as ExpressRequest } from 'express'
-import { pickBy, Dictionary, isString, mapKeys } from 'lodash'
+import { Dictionary, isString, mapKeys, pickBy } from 'lodash'
 import { FastifyRequest } from 'fastify'
 
 function isRecord(data: unknown): data is Record<string, unknown> {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -56,6 +56,7 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
     switch (ctx.getType()) {
         case 'http':
             const request: ExpressRequest | FastifyRequest = ctx.switchToHttp().getRequest()
+            query = request.query as Record<string, unknown>
 
             // Determine if Express or Fastify to rebuild the original url and reduce down to protocol, host and base url
             let originalUrl: string

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -355,16 +355,6 @@ export async function paginate<T extends ObjectLiteral>(
         items = await queryBuilder.getMany()
     }
 
-    let path: string
-    const { queryOrigin, queryPath } = getQueryUrlComponents(query.path)
-    if (config.relativePath) {
-        path = queryPath
-    } else if (config.origin) {
-        path = config.origin + queryPath
-    } else {
-        path = queryOrigin + queryPath
-    }
-
     const sortByQuery = sortBy.map((order) => `&sortBy=${order.join(':')}`).join('')
     const searchQuery = query.search ? `&search=${query.search}` : ''
 
@@ -389,6 +379,18 @@ export async function paginate<T extends ObjectLiteral>(
 
     const options = `&limit=${limit}${sortByQuery}${searchQuery}${searchByQuery}${selectQuery}${filterQuery}`
 
+    let path: string = null
+    if (query.path) {
+        // `query.path` does not exist in RPC/WS requests
+        const { queryOrigin, queryPath } = getQueryUrlComponents(query.path)
+        if (config.relativePath) {
+            path = queryPath
+        } else if (config.origin) {
+            path = config.origin + queryPath
+        } else {
+            path = queryOrigin + queryPath
+        }
+    }
     const buildLink = (p: number): string => path + '?page=' + p + options
 
     const totalPages = isPaginated ? Math.ceil(totalItems / limit) : 1
@@ -406,13 +408,16 @@ export async function paginate<T extends ObjectLiteral>(
             select: isQuerySelected ? selectParams : undefined,
             filter: query.filter,
         },
-        links: {
-            first: page == 1 ? undefined : buildLink(1),
-            previous: page - 1 < 1 ? undefined : buildLink(page - 1),
-            current: buildLink(page),
-            next: page + 1 > totalPages ? undefined : buildLink(page + 1),
-            last: page == totalPages || !totalItems ? undefined : buildLink(totalPages),
-        },
+        // If there is no `path`, don't build links.
+        links: path
+            ? {
+                  first: page == 1 ? undefined : buildLink(1),
+                  previous: page - 1 < 1 ? undefined : buildLink(page - 1),
+                  current: buildLink(page),
+                  next: page + 1 > totalPages ? undefined : buildLink(page + 1),
+                  last: page == totalPages || !totalItems ? undefined : buildLink(totalPages),
+              }
+            : ({} as Paginated<T>['links']),
     }
 
     return Object.assign(new Paginated<T>(), results)

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -380,8 +380,8 @@ export async function paginate<T extends ObjectLiteral>(
     const options = `&limit=${limit}${sortByQuery}${searchQuery}${searchByQuery}${selectQuery}${filterQuery}`
 
     let path: string = null
-    if (query.path) {
-        // `query.path` does not exist in RPC/WS requests
+    if (query.path !== null) {
+        // `query.path` does not exist in RPC/WS requests and is set to null then.
         const { queryOrigin, queryPath } = getQueryUrlComponents(query.path)
         if (config.relativePath) {
             path = queryPath
@@ -409,15 +409,16 @@ export async function paginate<T extends ObjectLiteral>(
             filter: query.filter,
         },
         // If there is no `path`, don't build links.
-        links: path
-            ? {
-                  first: page == 1 ? undefined : buildLink(1),
-                  previous: page - 1 < 1 ? undefined : buildLink(page - 1),
-                  current: buildLink(page),
-                  next: page + 1 > totalPages ? undefined : buildLink(page + 1),
-                  last: page == totalPages || !totalItems ? undefined : buildLink(totalPages),
-              }
-            : ({} as Paginated<T>['links']),
+        links:
+            path !== null
+                ? {
+                      first: page == 1 ? undefined : buildLink(1),
+                      previous: page - 1 < 1 ? undefined : buildLink(page - 1),
+                      current: buildLink(page),
+                      next: page + 1 > totalPages ? undefined : buildLink(page + 1),
+                      last: page == totalPages || !totalItems ? undefined : buildLink(totalPages),
+                  }
+                : ({} as Paginated<T>['links']),
     }
 
     return Object.assign(new Paginated<T>(), results)


### PR DESCRIPTION
### Problem

Currently, when the `@Paginate()` decorator is used alongside the `@MessagePattern()` decorator within a NestJS microservice, an error is thrown. This occurs because `ExecutionContextHost.switchToHttp().getRequest()` does not contain a `query` key in 'rpc' mode, leading to `undefined` being returned and causing the following `TypeError`:

```
TypeError: Cannot read properties of undefined (reading 'searchBy')
```

This error specifically arises due to the incompatibility of the `@Paginate()` decorator expecting HTTP request objects in an environment where such objects are not available.