### PR TITLE
JSON:API compliant query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following code exposes a route that can be utilized like so:
 #### Endpoint
 
 ```url
-http://localhost:3000/cats?limit=5&page=2&sortBy=color:DESC&search=i&filter.age=$gte:3&select=id,name,color,age
+http://localhost:3000/cats?page[number]=2&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age
 ```
 
 #### Result
@@ -84,11 +84,11 @@ http://localhost:3000/cats?limit=5&page=2&sortBy=color:DESC&search=i&filter.age=
     }
   },
   "links": {
-    "first": "http://localhost:3000/cats?limit=5&page=1&sortBy=color:DESC&search=i&filter.age=$gte:3",
-    "previous": "http://localhost:3000/cats?limit=5&page=1&sortBy=color:DESC&search=i&filter.age=$gte:3",
-    "current": "http://localhost:3000/cats?limit=5&page=2&sortBy=color:DESC&search=i&filter.age=$gte:3",
-    "next": "http://localhost:3000/cats?limit=5&page=3&sortBy=color:DESC&search=i&filter.age=$gte:3",
-    "last": "http://localhost:3000/cats?limit=5&page=3&sortBy=color:DESC&search=i&filter.age=$gte:3"
+    "first": "http://localhost:3000/cats?page[number]=1&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age",
+    "previous": "http://localhost:3000/cats?page[number]=1&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age",
+    "current": "http://localhost:3000/cats?page[number]=2&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age",
+    "next": "http://localhost:3000/cats?page[number]=3&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age",
+    "last": "http://localhost:3000/cats?page[number]=3&page[size]=5&sort=-color&@search=i&filter[age]=$gte:3&select=id,name,color,age"
   }
 }
 ```
@@ -323,7 +323,7 @@ Similar as with repositories, you can utilize `relations` as a simplified left-j
 #### Endpoint
 
 ```url
-http://localhost:3000/cats?filter.toys.name=$in:Mouse,String
+http://localhost:3000/cats?filter[toys][name]=$in:Mouse,String
 ```
 
 #### Code
@@ -359,7 +359,7 @@ Similar as with relations, you can specify nested relations for sorting, filteri
 #### Endpoint
 
 ```url
-http://localhost:3000/cats?filter.home.pillows.color=pink
+http://localhost:3000/cats?filter[home][pillows][color=pink
 ```
 
 #### Code
@@ -428,27 +428,27 @@ const config: PaginateConfig<CatEntity> = {
 }
 ```
 
-`?filter.name=$eq:Milo` is equivalent with `?filter.name=Milo`
+`?filter[name]=$eq:Milo` is equivalent with `?filter[name]=Milo`
 
-`?filter.age=$btw:4,6` where column `age` is between `4` and `6`
+`?filter[age]=$btw:4,6` where column `age` is between `4` and `6`
 
-`?filter.id=$not:$in:2,5,7` where column `id` is **not** `2`, `5` or `7`
+`?filter[id]=$not:$in:2,5,7` where column `id` is **not** `2`, `5` or `7`
 
-`?filter.summary=$not:$ilike:term` where column `summary` does **not** contain `term`
+`?filter[summary]=$not:$ilike:term` where column `summary` does **not** contain `term`
 
-`?filter.summary=$sw:term` where column `summary` starts with `term`
+`?filter[summary]=$sw:term` where column `summary` starts with `term`
 
-`?filter.seenAt=$null` where column `seenAt` is `NULL`
+`?filter[seenAt]=$null` where column `seenAt` is `NULL`
 
-`?filter.seenAt=$not:$null` where column `seenAt` is **not** `NULL`
+`?filter[seenAt]=$not:$null` where column `seenAt` is **not** `NULL`
 
-`?filter.createdAt=$btw:2022-02-02,2022-02-10` where column `createdAt` is between the dates `2022-02-02` and `2022-02-10`
+`?filter[createdAt]=$btw:2022-02-02,2022-02-10` where column `createdAt` is between the dates `2022-02-02` and `2022-02-10`
 
-`?filter.createdAt=$lt:2022-12-20T10:00:00.000Z` where column `createdAt` is before iso date `2022-12-20T10:00:00.000Z`
+`?filter[createdAt]=$lt:2022-12-20T10:00:00.000Z` where column `createdAt` is before iso date `2022-12-20T10:00:00.000Z`
 
-`?filter.roles=$contains:moderator` where column `roles` is an array and contains the value `moderator`
+`?filter[roles]=$contains:moderator` where column `roles` is an array and contains the value `moderator`
 
-`?filter.roles=$contains:moderator,admin` where column `roles` is an array and contains the values `moderator` and `admin`
+`?filter[roles]=$contains:moderator,admin` where column `roles` is an array and contains the values `moderator` and `admin`
 
 ## Multi Filters
 
@@ -456,19 +456,19 @@ Multi filters are filters that can be applied to a single column with a comparat
 
 ### Examples
 
-`?filter.createdAt=$gt:2022-02-02&filter.createdAt=$lt:2022-02-10` where column `createdAt` is after `2022-02-02` **and** before `2022-02-10`
+`?filter[createdAt]=$gt:2022-02-02&filter[createdAt]=$lt:2022-02-10` where column `createdAt` is after `2022-02-02` **and** before `2022-02-10`
 
-`?filter.id=$contains:moderator&filter.id=$or:$contains:admin` where column `roles` is an array and contains `moderator` **or** `admin`
+`?filter[id]=$contains:moderator&filter[id]=$or:$contains:admin` where column `roles` is an array and contains `moderator` **or** `admin`
 
-`?filter.id=$gt:3&filter.id=$and:$lt:5&filter.id=$or:$eq:7` where column `id` is greater than `3` **and** less than `5` **or** equal to `7`
+`?filter[id]=$gt:3&filter[id]=$and:$lt:5&filter[id]=$or:$eq:7` where column `id` is greater than `3` **and** less than `5` **or** equal to `7`
 
 **Note:** The `$and` comparators are not required. The above example is equivalent to:
 
-`?filter.id=$gt:3&filter.id=$lt:5&filter.id=$or:$eq:7`
+`?filter[id]=$gt:3&filter[id]=$lt:5&filter[id]=$or:$eq:7`
 
 **Note:** The first comparator on the the first filter is ignored because the filters are grouped by the column name and chained with an `$and` to other filters.
 
-`...&filter.id=5&filter.id=$or:7&filter.name=Milo&...`
+`...&filter[id]=5&filter[id]=$or:7&filter[name]=Milo&...`
 
 is resolved to:
 
@@ -476,11 +476,12 @@ is resolved to:
 
 ## Swagger
 
-You can use two default decorators @ApiOkResponsePaginated and @ApiPagination to generate swagger documentation for your endpoints
+You can use two default decorators `@ApiOkResponsePaginated` and `@ApiPagination`
+to generate swagger documentation for your endpoints.
 
-`@ApiOkPaginatedResponse` is for response body, return http[](https://) status is 200
+`@ApiOkPaginatedResponse` is for response body, http status is 200.
 
-`@ApiPaginationQuery` is for query params
+`@ApiPaginationQuery` is for query params.
 
 ```typescript
   @Get()
@@ -497,7 +498,7 @@ You can use two default decorators @ApiOkResponsePaginated and @ApiPagination to
   }
 ```
 
-There is also some syntax sugar for this, and you can use only one decorator `@PaginatedSwaggerDocs` for both response body and query params
+There is also some syntax sugar for this, and you can use only one decorator `@PaginatedSwaggerDocs` for both response body and query params:
 
 ```typescript
   @Get()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,22 +12,22 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@nestjs/common": "^10.3.3",
-        "@nestjs/platform-express": "^10.3.3",
-        "@nestjs/testing": "^10.3.3",
+        "@nestjs/common": "^10.3.8",
+        "@nestjs/platform-express": "^10.3.8",
+        "@nestjs/testing": "^10.3.8",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
-        "@types/lodash": "^4.14.202",
-        "@types/node": "^20.11.20",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
+        "@types/lodash": "^4.17.0",
+        "@types/node": "^20.12.7",
+        "@typescript-eslint/eslint-plugin": "^7.4.0",
+        "@typescript-eslint/parser": "^7.4.0",
         "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "fastify": "^4.26.1",
+        "fastify": "^4.26.2",
         "jest": "^29.7.0",
-        "pg": "^8.11.3",
+        "pg": "^8.11.5",
         "prettier": "^3.0.3",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1",
@@ -35,13 +35,13 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "typeorm": "^0.3.17",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "@nestjs/common": "^10.3.3",
+        "@nestjs/common": "^10.3.8",
         "@nestjs/swagger": "^7.3.0",
-        "express": "^4.18.2",
-        "fastify": "^4.26.1",
+        "express": "^4.19.2",
+        "fastify": "^4.26.2",
         "typeorm": "^0.3.17"
       }
     },
@@ -1334,9 +1334,9 @@
       "peer": true
     },
     "node_modules/@nestjs/common": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.3.tgz",
-      "integrity": "sha512-LAkTe8/CF0uNWM0ecuDwUNTHCi1lVSITmmR4FQ6Ftz1E7ujQCnJ5pMRzd8JRN14vdBkxZZ8VbVF0BDUKoKNxMQ==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.8.tgz",
+      "integrity": "sha512-P+vPEIvqx2e+fonsYVlFXKvoChyJ8Tq+lfpqdVFqblovHbFr3kZ/nYX0cPs+XuW6bnRT8tz0SSR9XBGU43kJhw==",
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.6.2",
@@ -1431,14 +1431,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.3.tgz",
-      "integrity": "sha512-GGKSEU48Os7nYFIsUM0nutuFUGn5AbeP8gzFBiBCAtiuJWrXZXpZ58pMBYxAbMf7IrcOZFInHEukjHGAQU0OZw==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.8.tgz",
+      "integrity": "sha512-sifLoxgEJvAgbim1UuW6wyScMfkS9SVQRH+lN33N/9ZvZSjO6NSDLOe+wxqsnZkia+QrjFC0qy0ITRAsggfqbg==",
       "devOptional": true,
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
-        "express": "4.18.2",
+        "express": "4.19.2",
         "multer": "1.4.4-lts.1",
         "tslib": "2.6.2"
       },
@@ -1449,60 +1449,6 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "devOptional": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "devOptional": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "devOptional": true
-    },
-    "node_modules/@nestjs/platform-express/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "devOptional": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/@nestjs/platform-express/node_modules/tslib": {
@@ -1551,9 +1497,9 @@
       "peer": true
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.3.tgz",
-      "integrity": "sha512-kX20GfjAImL5grd/i69uD/x7sc00BaqGcP2dRG3ilqshQUuy5DOmspLCr3a2C8xmVU7kzK4spT0oTxhe6WcCAA==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.8.tgz",
+      "integrity": "sha512-hpX9das2TdFTKQ4/2ojhjI6YgXtCfXRKui3A4Qaj54VVzc5+mtK502Jj18Vzji98o9MVS6skmYu+S/UvW3U6Fw==",
       "dev": true,
       "dependencies": {
         "tslib": "2.6.2"
@@ -1878,9 +1824,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -1890,9 +1836,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
-      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1911,9 +1857,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
     },
     "node_modules/@types/serve-static": {
@@ -1948,16 +1894,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/type-utils": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1966,15 +1912,15 @@
         "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1983,26 +1929,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2011,16 +1957,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2028,25 +1974,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2055,12 +2001,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2068,13 +2014,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2083,7 +2029,7 @@
         "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2120,41 +2066,41 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
         "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/types": "7.4.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2655,12 +2601,12 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2668,7 +2614,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -2802,15 +2748,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "devOptional": true
-    },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/bundle-name": {
       "version": "3.0.0",
@@ -3163,6 +3100,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4016,16 +3954,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4054,6 +3992,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -4200,9 +4146,9 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.1.tgz",
-      "integrity": "sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
+      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
       "dev": true,
       "funding": [
         {
@@ -6451,12 +6397,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-      "dev": true
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6564,16 +6504,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
       "dev": true,
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -6600,9 +6538,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -6615,18 +6553,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -7025,9 +6963,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -8309,9 +8247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9657,9 +9595,9 @@
       "peer": true
     },
     "@nestjs/common": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.3.tgz",
-      "integrity": "sha512-LAkTe8/CF0uNWM0ecuDwUNTHCi1lVSITmmR4FQ6Ftz1E7ujQCnJ5pMRzd8JRN14vdBkxZZ8VbVF0BDUKoKNxMQ==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.8.tgz",
+      "integrity": "sha512-P+vPEIvqx2e+fonsYVlFXKvoChyJ8Tq+lfpqdVFqblovHbFr3kZ/nYX0cPs+XuW6bnRT8tz0SSR9XBGU43kJhw==",
       "requires": {
         "iterare": "1.2.1",
         "tslib": "2.6.2",
@@ -9703,65 +9641,18 @@
       "requires": {}
     },
     "@nestjs/platform-express": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.3.tgz",
-      "integrity": "sha512-GGKSEU48Os7nYFIsUM0nutuFUGn5AbeP8gzFBiBCAtiuJWrXZXpZ58pMBYxAbMf7IrcOZFInHEukjHGAQU0OZw==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.8.tgz",
+      "integrity": "sha512-sifLoxgEJvAgbim1UuW6wyScMfkS9SVQRH+lN33N/9ZvZSjO6NSDLOe+wxqsnZkia+QrjFC0qy0ITRAsggfqbg==",
       "devOptional": true,
       "requires": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
-        "express": "4.18.2",
+        "express": "4.19.2",
         "multer": "1.4.4-lts.1",
         "tslib": "2.6.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.20.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-          "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-          "devOptional": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "content-type": "~1.0.5",
-            "debug": "2.6.9",
-            "depd": "2.0.0",
-            "destroy": "1.2.0",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "on-finished": "2.4.1",
-            "qs": "6.11.0",
-            "raw-body": "2.5.2",
-            "type-is": "~1.6.18",
-            "unpipe": "1.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "devOptional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "devOptional": true
-        },
-        "raw-body": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-          "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-          "devOptional": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
-        },
         "tslib": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -9793,9 +9684,9 @@
       }
     },
     "@nestjs/testing": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.3.tgz",
-      "integrity": "sha512-kX20GfjAImL5grd/i69uD/x7sc00BaqGcP2dRG3ilqshQUuy5DOmspLCr3a2C8xmVU7kzK4spT0oTxhe6WcCAA==",
+      "version": "10.3.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.8.tgz",
+      "integrity": "sha512-hpX9das2TdFTKQ4/2ojhjI6YgXtCfXRKui3A4Qaj54VVzc5+mtK502Jj18Vzji98o9MVS6skmYu+S/UvW3U6Fw==",
       "dev": true,
       "requires": {
         "tslib": "2.6.2"
@@ -10076,9 +9967,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "@types/mime": {
@@ -10088,9 +9979,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.11.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
-      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -10109,9 +10000,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
     },
     "@types/serve-static": {
@@ -10146,16 +10037,16 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/type-utils": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -10165,54 +10056,54 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -10242,27 +10133,27 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
         "semver": "^7.5.4"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/types": "7.4.0",
         "eslint-visitor-keys": "^3.4.1"
       }
     },
@@ -10638,12 +10529,12 @@
       }
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -10651,7 +10542,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -10744,12 +10635,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "devOptional": true
-    },
-    "buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "dev": true
     },
     "bundle-name": {
       "version": "3.0.0",
@@ -11027,7 +10912,8 @@
     "cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -11607,16 +11493,16 @@
       }
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -11644,6 +11530,11 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+          "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11781,9 +11672,9 @@
       "dev": true
     },
     "fastify": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.1.tgz",
-      "integrity": "sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
+      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",
@@ -13482,12 +13373,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-      "dev": true
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13573,17 +13458,15 @@
       "dev": true
     },
     "pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
       "dev": true,
       "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
         "pg-cloudflare": "^1.1.1",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
@@ -13596,9 +13479,9 @@
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA==",
       "dev": true
     },
     "pg-int8": {
@@ -13608,16 +13491,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
       "dev": true
     },
     "pg-types": {
@@ -13909,9 +13792,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -14779,9 +14662,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "uid": {

--- a/package.json
+++ b/package.json
@@ -32,22 +32,22 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "devDependencies": {
-    "@nestjs/common": "^10.3.3",
-    "@nestjs/platform-express": "^10.3.3",
-    "@nestjs/testing": "^10.3.3",
+    "@nestjs/common": "^10.3.8",
+    "@nestjs/platform-express": "^10.3.8",
+    "@nestjs/testing": "^10.3.8",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
-    "@types/lodash": "^4.14.202",
-    "@types/node": "^20.11.20",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
+    "@types/lodash": "^4.17.0",
+    "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "fastify": "^4.26.1",
+    "fastify": "^4.26.2",
     "jest": "^29.7.0",
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
     "prettier": "^3.0.3",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1",
@@ -55,16 +55,16 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typeorm": "^0.3.17",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.3.3",
+    "@nestjs/common": "^10.3.8",
     "@nestjs/swagger": "^7.3.0",
-    "express": "^4.18.2",
-    "fastify": "^4.26.1",
+    "express": "^4.19.2",
+    "fastify": "^4.26.2",
     "typeorm": "^0.3.17"
   },
   "jest": {

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -87,7 +87,7 @@ describe('Decorator', () => {
     it('should handle express defined query fields', () => {
         const context = expressContextFactory({
             page: { number: '1', size: '20' },
-            sortBy: ['id:ASC', 'createdAt:DESC'],
+            sort: 'id,-createdAt',
             search: 'white',
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
@@ -117,7 +117,7 @@ describe('Decorator', () => {
     it('should handle express partially defined query families', () => {
         const context = expressContextFactory({
             page: { number: '1' },
-            sortBy: ['id:ASC', 'createdAt:DESC'],
+            sort: 'id,-createdAt',
             search: 'white',
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
@@ -150,7 +150,7 @@ describe('Decorator', () => {
                 number: '1',
                 size: '20',
             },
-            sortBy: ['id:ASC', 'createdAt:DESC'],
+            sort: 'id,-createdAt',
             search: 'white',
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
@@ -183,7 +183,7 @@ describe('Decorator', () => {
                 number: '1',
                 size: '20',
             },
-            sortBy: ['id:ASC', 'createdAt:DESC'],
+            sort: 'id,-createdAt',
             search: 'white',
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -86,8 +86,7 @@ describe('Decorator', () => {
 
     it('should handle express defined query fields', () => {
         const context = expressContextFactory({
-            page: '1',
-            limit: '20',
+            page: { number: '1', size: '20' },
             sortBy: ['id:ASC', 'createdAt:DESC'],
             search: 'white',
             'filter.name': '$not:$eq:Kitty',
@@ -115,10 +114,75 @@ describe('Decorator', () => {
         })
     })
 
+    it('should handle express partially defined query families', () => {
+        const context = expressContextFactory({
+            page: { number: '1' },
+            sortBy: ['id:ASC', 'createdAt:DESC'],
+            search: 'white',
+            'filter.name': '$not:$eq:Kitty',
+            'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
+            select: ['name', 'createdAt'],
+        })
+
+        const result: PaginateQuery = decoratorfactory(null, context)
+
+        expect(result).toStrictEqual({
+            page: 1,
+            limit: undefined,
+            sortBy: [
+                ['id', 'ASC'],
+                ['createdAt', 'DESC'],
+            ],
+            search: 'white',
+            searchBy: undefined,
+            select: ['name', 'createdAt'],
+            path: 'http://localhost/items',
+            filter: {
+                name: '$not:$eq:Kitty',
+                createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
+            },
+        })
+    })
+
     it('should handle fastify defined query fields', () => {
         const context = fastifyContextFactory({
-            page: '1',
-            limit: '20',
+            page: {
+                number: '1',
+                size: '20',
+            },
+            sortBy: ['id:ASC', 'createdAt:DESC'],
+            search: 'white',
+            'filter.name': '$not:$eq:Kitty',
+            'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
+            select: ['name', 'createdAt'],
+        })
+
+        const result: PaginateQuery = decoratorfactory(null, context)
+
+        expect(result).toStrictEqual({
+            page: 1,
+            limit: 20,
+            sortBy: [
+                ['id', 'ASC'],
+                ['createdAt', 'DESC'],
+            ],
+            search: 'white',
+            searchBy: undefined,
+            path: 'http://localhost/items',
+            filter: {
+                name: '$not:$eq:Kitty',
+                createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
+            },
+            select: ['name', 'createdAt'],
+        })
+    })
+
+    it('should handle fastify defined query fields', () => {
+        const context = fastifyContextFactory({
+            page: {
+                number: '1',
+                size: '20',
+            },
             sortBy: ['id:ASC', 'createdAt:DESC'],
             search: 'white',
             'filter.name': '$not:$eq:Kitty',

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -99,7 +99,7 @@ describe('Decorator', () => {
 
         const result: PaginateQuery = decoratorFactory(null, context)
 
-        expect(result).toStrictEqual(resultFactory({ search: '432', searchBy: undefined }))
+        expect(result).toStrictEqual(resultFactory({ search: '432' }))
     })
 
     it('should handle express defined query fields', () => {
@@ -113,7 +113,7 @@ describe('Decorator', () => {
 
         const result: PaginateQuery = decoratorFactory(null, context)
 
-        expect(result).toStrictEqual({
+        expect(result).toStrictEqual(resultFactory({
             page: 1,
             limit: 20,
             sortBy: [
@@ -121,14 +121,12 @@ describe('Decorator', () => {
                 ['createdAt', 'DESC'],
             ],
             search: 'white',
-            searchBy: undefined,
             select: ['name', 'createdAt'],
-            path: 'http://localhost/items',
             filter: {
                 name: '$not:$eq:Kitty',
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
-        })
+        }))
     })
 
     it('should handle express partially defined query families', () => {
@@ -142,22 +140,19 @@ describe('Decorator', () => {
 
         const result: PaginateQuery = decoratorFactory(null, context)
 
-        expect(result).toStrictEqual({
+        expect(result).toStrictEqual(resultFactory({
             page: 1,
-            limit: undefined,
             sortBy: [
                 ['id', 'ASC'],
                 ['createdAt', 'DESC'],
             ],
             search: 'white',
-            searchBy: undefined,
             select: ['name', 'createdAt'],
-            path: 'http://localhost/items',
             filter: {
                 name: '$not:$eq:Kitty',
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
-        })
+        }))
     })
 
     it('should handle fastify defined query fields', () => {
@@ -174,7 +169,7 @@ describe('Decorator', () => {
 
         const result: PaginateQuery = decoratorFactory(null, context)
 
-        expect(result).toStrictEqual({
+        expect(result).toStrictEqual(resultFactory({
             page: 1,
             limit: 20,
             sortBy: [
@@ -182,45 +177,11 @@ describe('Decorator', () => {
                 ['createdAt', 'DESC'],
             ],
             search: 'white',
-            searchBy: undefined,
-            path: 'http://localhost/items',
             filter: {
                 name: '$not:$eq:Kitty',
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
             select: ['name', 'createdAt'],
-        })
-    })
-
-    it('should handle fastify defined query fields', () => {
-        const context = fastifyContextFactory({
-            page: {
-                number: '1',
-                size: '20',
-            },
-            sort: 'id,-createdAt',
-            ['@search']: 'white',
-            filter: { name: '$not:$eq:Kitty', createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'] },
-            select: 'name,createdAt',
-        })
-
-        const result: PaginateQuery = decoratorFactory(null, context)
-
-        expect(result).toStrictEqual({
-            page: 1,
-            limit: 20,
-            sortBy: [
-                ['id', 'ASC'],
-                ['createdAt', 'DESC'],
-            ],
-            search: 'white',
-            searchBy: undefined,
-            path: 'http://localhost/items',
-            filter: {
-                name: '$not:$eq:Kitty',
-                createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
-            },
-            select: ['name', 'createdAt'],
-        })
+        }))
     })
 })

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -22,20 +22,23 @@ export interface PaginateQuery {
     path: string
 }
 
-const parseInteger = (param: unknown): number  | undefined =>
-    param === undefined || param === null ? undefined: parseInt(param as string, 10)
-const parseString = (param: unknown): string  | undefined =>
+const parseInteger = (param: unknown): number | undefined =>
+    param === undefined || param === null ? undefined : parseInt(param as string, 10)
+
+const parseString = (param: unknown): string | undefined =>
     param === undefined || param === null ? undefined : String(param)
-const parseOneOrManyString = (param: unknown): string[] | string  | undefined =>
+
+const parseOneOrManyString = (param: unknown): string[] | string | undefined =>
     Array.isArray(param) ? param.map(parseString) : parseString(param)
+
 const parseSort = (params: string[]) => {
     return params.map((param): [string, 'ASC' | 'DESC'] =>
         param.startsWith('-') ? [param.slice(1), 'DESC'] : [param, 'ASC']
     )
 }
 
-function parseFamilyParam(family: unknown, key: string): string  | undefined
-function parseFamilyParam<T>(family: unknown, key: string, parser: (value: string) => T): T  | undefined
+function parseFamilyParam(family: unknown, key: string): string | undefined
+function parseFamilyParam<T>(family: unknown, key: string, parser: (value: string) => T): T | undefined
 function parseFamilyParam<T>(
     family: unknown,
     key: string,
@@ -61,7 +64,7 @@ function parseFamilyParams<K extends { [key: string]: any }>(
     }
 }
 
-function parseFamily(family: unknown): Record<string, string  | undefined> | undefined
+function parseFamily(family: unknown): Record<string, string | undefined> | undefined
 function parseFamily<T>(family: unknown, parser: (value: string) => T): Record<string, T> | undefined
 function parseFamily<T>(
     family: unknown,

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -22,11 +22,11 @@ export interface PaginateQuery {
     path: string
 }
 
-const parseInteger = (param: unknown): number | null | undefined =>
-    param === undefined || param === null ? (param as null | undefined) : parseInt(param as string, 10)
-const parseString = (param: unknown): string | null | undefined =>
-    param === undefined || param === null ? (param as null | undefined) : String(param)
-const parseOneOrManyString = (param: unknown): string[] | string | null | undefined =>
+const parseInteger = (param: unknown): number  | undefined =>
+    param === undefined || param === null ? undefined: parseInt(param as string, 10)
+const parseString = (param: unknown): string  | undefined =>
+    param === undefined || param === null ? undefined : String(param)
+const parseOneOrManyString = (param: unknown): string[] | string  | undefined =>
     Array.isArray(param) ? param.map(parseString) : parseString(param)
 const parseSort = (params: string[]) => {
     return params.map((param): [string, 'ASC' | 'DESC'] =>
@@ -34,8 +34,8 @@ const parseSort = (params: string[]) => {
     )
 }
 
-function parseFamilyParam(family: unknown, key: string): string | null | undefined
-function parseFamilyParam<T>(family: unknown, key: string, parser: (value: string) => T): T | null | undefined
+function parseFamilyParam(family: unknown, key: string): string  | undefined
+function parseFamilyParam<T>(family: unknown, key: string, parser: (value: string) => T): T  | undefined
 function parseFamilyParam<T>(
     family: unknown,
     key: string,
@@ -61,7 +61,7 @@ function parseFamilyParams<K extends { [key: string]: any }>(
     }
 }
 
-function parseFamily(family: unknown): Record<string, string | null | undefined> | undefined
+function parseFamily(family: unknown): Record<string, string  | undefined> | undefined
 function parseFamily<T>(family: unknown, parser: (value: string) => T): Record<string, T> | undefined
 function parseFamily<T>(
     family: unknown,
@@ -113,7 +113,7 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
               })
             : searchQuery
             ? { query: searchQuery }
-            : (searchQuery as null | undefined)
+            : undefined
 
     // Assemble the PaginateQuery
     return {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -49,6 +49,14 @@ function parseParam<T>(queryParam: unknown, parserLogic: (param: string, res: an
     return res.length ? res : undefined
 }
 
+function parseFamilyParam<T>(family: unknown, key: string, parser: (value: string) => T): T | undefined {
+    if (!(typeof family === 'object') || family[key] === undefined) {
+        return undefined
+    } else {
+        return parser(family[key].toString())
+    }
+}
+
 export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionContext): PaginateQuery => {
     const request: ExpressRequest | FastifyRequest = ctx.switchToHttp().getRequest()
     const query = request.query as Record<string, unknown>
@@ -76,10 +84,9 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
         ) as Dictionary<string | string[]>,
         (_param, name) => name.replace('filter.', '')
     )
-
     return {
-        page: query.page ? parseInt(query.page.toString(), 10) : undefined,
-        limit: query.limit ? parseInt(query.limit.toString(), 10) : undefined,
+        page: parseFamilyParam(query.page, 'number', (value) => parseInt(value, 10)),
+        limit: parseFamilyParam(query.page, 'size', (value) => parseInt(value, 10)),
         sortBy,
         search: query.search ? query.search.toString() : undefined,
         searchBy,

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -512,7 +512,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.sortBy).toStrictEqual([['id', 'DESC']])
+        expect(result.meta.sort).toStrictEqual([['id', 'DESC']])
         expect(result.data).toStrictEqual(cats.slice(0).reverse())
     })
 
@@ -529,7 +529,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         const expectedResult = [...cats.slice(0, -1).reverse(), cats.slice(-1)[0]]
 
-        expect(result.meta.sortBy).toStrictEqual([['age', 'ASC']])
+        expect(result.meta.sort).toStrictEqual([['age', 'ASC']])
         expect(result.data).toStrictEqual(expectedResult)
     })
 
@@ -547,7 +547,7 @@ describe('paginate', () => {
 
         const expectedResult = [cats[cats.length - 1], ...cats.slice(0, cats.length - 1).reverse()]
 
-        expect(result.meta.sortBy).toStrictEqual([['age', 'ASC']])
+        expect(result.meta.sort).toStrictEqual([['age', 'ASC']])
         expect(result.data).toStrictEqual(expectedResult)
     })
 
@@ -565,7 +565,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.sortBy).toStrictEqual([
+        expect(result.meta.sort).toStrictEqual([
             ['color', 'DESC'],
             ['name', 'ASC'],
         ])
@@ -586,7 +586,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.sortBy).toStrictEqual([
+        expect(result.meta.sort).toStrictEqual([
             ['cutenessLevel', 'ASC'],
             ['name', 'ASC'],
         ])
@@ -698,7 +698,7 @@ describe('paginate', () => {
         }
 
         const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
-        expect(result.meta.sortBy).toStrictEqual([['cat.id', 'DESC']])
+        expect(result.meta.sort).toStrictEqual([['cat.id', 'DESC']])
 
         const catHomesClone = clone([catHomes[0], catHomes[1]])
         catHomesClone[0].countCat = cats.filter((cat) => cat.id === catHomesClone[0].cat.id).length
@@ -879,7 +879,9 @@ describe('paginate', () => {
         expect(result.meta.search.query).toStrictEqual(searchTerm)
         expect(result.meta.search.fields).toStrictEqual(['color'])
         expect(result.data).toStrictEqual(expectedResultData)
-        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=white&@search[fields]=color')
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&@search[query]=white&@search[fields]=color'
+        )
     })
 
     it('should return result based on where config and filter', async () => {
@@ -947,7 +949,7 @@ describe('paginate', () => {
         }
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
-        
+
         expect(result.meta.page.totalItems).toBe(3)
         result.data.forEach((toy) => {
             expect(toy.cat.id).toBe(cats[0].id)
@@ -2177,7 +2179,7 @@ describe('paginate', () => {
             cats.filter((cat) => (cat.name === 'Milo' || cat.color === 'white') && cat.age)
         )
         expect(result.links.current).toBe(
-            '?page=1&limit=20&sortBy=id:ASC&filter.name=$or:Milo&filter.color=$or:white&filter.age=$btw:1,10'
+            '?page[number]=1&page[size]=20&sort=id&filter[name]=$or:Milo&filter[color]=$or:white&filter[age]=$btw:1,10'
         )
     })
 
@@ -2550,8 +2552,10 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data.length).toEqual(0)
-        expect(result.meta.searchBy).toStrictEqual(['color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo&searchBy=color')
+        expect(result.meta.search).toStrictEqual({ fields: ['color'], query: 'Milo' })
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&@search[query]=Milo&@search[fields]=color'
+        )
     })
 
     it('should use searchBy in query param when ignoreSearchByInQueryParam is set to false', async () => {
@@ -2568,8 +2572,10 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data.length).toEqual(0)
-        expect(result.meta.searchBy).toStrictEqual(['color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo&searchBy=color')
+        expect(result.meta.search).toStrictEqual({ fields: ['color'], query: 'Milo' })
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&@search[query]=Milo&@search[fields]=color'
+        )
     })
 
     it('should ignore searchBy in query param when ignoreSearchByInQueryParam is set to true', async () => {
@@ -2587,8 +2593,8 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data.length).toEqual(1)
         expect(result.data).toStrictEqual([cats[0]])
-        expect(result.meta.searchBy).toStrictEqual(['name', 'color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo')
+        expect(result.meta.search).toStrictEqual({ fields: ['name', 'color'], query: 'Milo' })
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=Milo')
     })
 
     it('should use select in query param when ignoreSelectInQueryParam is not defined', async () => {
@@ -2604,7 +2610,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data[0]).toEqual({ id: cats[0].id, color: cats[0].color })
         expect(result.meta.select).toStrictEqual(['id', 'color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,color')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&select=id,color')
     })
 
     it('should use select in query param when ignoreSelectInQueryParam is set to false', async () => {
@@ -2621,7 +2627,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data[0]).toEqual({ id: cats[0].id, color: cats[0].color })
         expect(result.meta.select).toStrictEqual(['id', 'color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,color')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&select=id,color')
     })
 
     it('should ignore select in query param when ignoreSelectInQueryParam is set to true', async () => {
@@ -2638,7 +2644,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         expect(result.data[0]).toEqual({ id: cats[0].id, color: cats[0].color, name: cats[0].name })
         expect(result.meta.select).toEqual(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     describe('should return result based on date column filter', () => {
@@ -2874,7 +2880,7 @@ describe('paginate', () => {
                     colors: queryFilter,
                 })
                 expect(result.data).toStrictEqual(expectedIndexes.map((index) => catHairs[index]))
-                expect(result.links.current).toBe(`?page=1&limit=20&sortBy=id:ASC&filter.colors=${queryFilter}`)
+                expect(result.links.current).toBe(`?page[number]=1&page[size]=20&sort=id&filter[colors]=${queryFilter}`)
             })
 
             it('should work with search', async () => {
@@ -2892,7 +2898,7 @@ describe('paginate', () => {
 
                 expect(result.meta.search).toStrictEqual('brown')
                 expect(result.data).toStrictEqual([catHairs[0], catHairs[1]])
-                expect(result.links.current).toBe(`?page=1&limit=20&sortBy=id:ASC&search=brown`)
+                expect(result.links.current).toBe(`?page[number]=1&page[size]=20&sort=id&search=brown`)
             })
         })
     }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -282,7 +282,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.currentPage).toBe(1)
+        expect(result.meta.page.number).toBe(1)
         expect(result.data).toStrictEqual(cats.slice(0, 1))
     })
 
@@ -409,11 +409,11 @@ describe('paginate', () => {
 
         const { links } = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(links.first).toBe('?page=1&limit=2&sortBy=id:ASC')
-        expect(links.previous).toBe('?page=1&limit=2&sortBy=id:ASC')
-        expect(links.current).toBe('?page=2&limit=2&sortBy=id:ASC')
-        expect(links.next).toBe('?page=3&limit=2&sortBy=id:ASC')
-        expect(links.last).toBe('?page=3&limit=2&sortBy=id:ASC')
+        expect(links.first).toBe('?page[number]=1&page[size]=2&sort=id')
+        expect(links.previous).toBe('?page[number]=1&page[size]=2&sort=id')
+        expect(links.current).toBe('?page[number]=2&page[size]=2&sort=id')
+        expect(links.next).toBe('?page[number]=3&page[size]=2&sort=id')
+        expect(links.last).toBe('?page[number]=3&page[size]=2&sort=id')
     })
 
     it('should return a relative path', async () => {
@@ -430,11 +430,11 @@ describe('paginate', () => {
 
         const { links } = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(links.first).toBe('/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.previous).toBe('/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.current).toBe('/cats?page=2&limit=2&sortBy=id:ASC')
-        expect(links.next).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
-        expect(links.last).toBe('/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.first).toBe('/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.previous).toBe('/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.current).toBe('/cats?page[number]=2&page[size]=2&sort=id')
+        expect(links.next).toBe('/cats?page[number]=3&page[size]=2&sort=id')
+        expect(links.last).toBe('/cats?page[number]=3&page[size]=2&sort=id')
     })
 
     it('should return an absolute path', async () => {
@@ -451,11 +451,11 @@ describe('paginate', () => {
 
         const { links } = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(links.first).toBe('http://localhost/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.previous).toBe('http://localhost/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.current).toBe('http://localhost/cats?page=2&limit=2&sortBy=id:ASC')
-        expect(links.next).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
-        expect(links.last).toBe('http://localhost/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.first).toBe('http://localhost/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.previous).toBe('http://localhost/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.current).toBe('http://localhost/cats?page[number]=2&page[size]=2&sort=id')
+        expect(links.next).toBe('http://localhost/cats?page[number]=3&page[size]=2&sort=id')
+        expect(links.last).toBe('http://localhost/cats?page[number]=3&page[size]=2&sort=id')
     })
 
     it('should return an absolute path with new origin', async () => {
@@ -473,11 +473,11 @@ describe('paginate', () => {
 
         const { links } = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(links.first).toBe('http://cats.example/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.previous).toBe('http://cats.example/cats?page=1&limit=2&sortBy=id:ASC')
-        expect(links.current).toBe('http://cats.example/cats?page=2&limit=2&sortBy=id:ASC')
-        expect(links.next).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
-        expect(links.last).toBe('http://cats.example/cats?page=3&limit=2&sortBy=id:ASC')
+        expect(links.first).toBe('http://cats.example/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.previous).toBe('http://cats.example/cats?page[number]=1&page[size]=2&sort=id')
+        expect(links.current).toBe('http://cats.example/cats?page[number]=2&page[size]=2&sort=id')
+        expect(links.next).toBe('http://cats.example/cats?page[number]=3&page[size]=2&sort=id')
+        expect(links.last).toBe('http://cats.example/cats?page[number]=3&page[size]=2&sort=id')
     })
 
     it('should return only current link if zero results', async () => {
@@ -496,7 +496,7 @@ describe('paginate', () => {
 
         expect(links.first).toBe(undefined)
         expect(links.previous).toBe(undefined)
-        expect(links.current).toBe('?page=1&limit=2&sortBy=id:ASC&search=Pluto')
+        expect(links.current).toBe('?page[number]=1&page[size]=2&sort=id&@search[query]=Pluto')
         expect(links.next).toBe(undefined)
         expect(links.last).toBe(undefined)
     })
@@ -605,9 +605,9 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('i')
+        expect(result.meta.search.query).toStrictEqual('i')
         expect(result.data).toStrictEqual([cats[0], cats[1], cats[3], cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=i')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=i')
     })
 
     it('should return result based on search term on a camelcase named column', async () => {
@@ -622,9 +622,9 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('hi')
+        expect(result.meta.search.query).toStrictEqual('hi')
         expect(result.data).toStrictEqual([cats[0], cats[2], cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=hi')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=hi')
     })
 
     it('should not result in a sql syntax error when attempting a sql injection', async () => {
@@ -655,9 +655,9 @@ describe('paginate', () => {
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
 
-        expect(result.meta.search).toStrictEqual('Milo')
+        expect(result.meta.search.query).toStrictEqual('Milo')
         expect(result.data).toStrictEqual([catToysWithoutShop[0], catToysWithoutShop[1], catToysWithoutShop[2]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Milo')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=Milo')
     })
 
     it('should return result based on search term on one-to-many relation', async () => {
@@ -677,14 +677,14 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('Mouse')
+        expect(result.meta.search.query).toStrictEqual('Mouse')
         const toy = clone(catToysWithoutShop[1])
         delete toy.cat
         const toy2 = clone(catToysWithoutShop[2])
         delete toy2.cat
 
         expect(result.data).toStrictEqual([Object.assign(clone(cats[0]), { toys: [toy2, toy] })])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&sortBy=toys.id:DESC&search=Mouse')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id,-toys.id&@search[query]=Mouse')
     })
 
     it('should return result based on search term on one-to-one relation', async () => {
@@ -705,7 +705,7 @@ describe('paginate', () => {
         catHomesClone[1].countCat = cats.filter((cat) => cat.id === catHomesClone[1].cat.id).length
 
         expect(result.data).toStrictEqual(catHomesClone.sort((a, b) => b.cat.id - a.cat.id))
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=cat.id:DESC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=-cat.id')
     })
 
     it('should return result based on sort and search on many-to-one relation', async () => {
@@ -722,11 +722,11 @@ describe('paginate', () => {
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
 
-        expect(result.meta.search).toStrictEqual('Milo')
+        expect(result.meta.search.query).toStrictEqual('Milo')
         expect(result.data).toStrictEqual(
             [catToysWithoutShop[0], catToysWithoutShop[1], catToysWithoutShop[2]].sort((a, b) => b.cat.id - a.cat.id)
         )
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=cat.id:DESC&search=Milo')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=-cat.id&@search[query]=Milo')
     })
 
     it('should return result based on sort on one-to-many relation', async () => {
@@ -743,7 +743,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('Mouse')
+        expect(result.meta.search.query).toStrictEqual('Mouse')
         const toy1 = clone(catToys[1])
         delete toy1.cat
         const toy2 = clone(catToys[2])
@@ -752,7 +752,7 @@ describe('paginate', () => {
         delete result.data[0].toys[0].shop.address
 
         expect(result.data).toStrictEqual([Object.assign(clone(cats[0]), { toys: [toy2, toy1] })])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=toys.id:DESC&search=Mouse')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=-toys.id&@search[query]=Mouse')
     })
 
     it('should return result based on sort on one-to-one relation', async () => {
@@ -768,13 +768,13 @@ describe('paginate', () => {
 
         const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
 
-        expect(result.meta.search).toStrictEqual('Garfield')
+        expect(result.meta.search.query).toStrictEqual('Garfield')
 
         const catHomesClone = clone(catHomes[1])
         catHomesClone.countCat = cats.filter((cat) => cat.id === catHomesClone.cat.id).length
 
         expect(result.data).toStrictEqual([catHomesClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=Garfield')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=Garfield')
     })
 
     it('should load nested relations (object notation)', async () => {
@@ -804,7 +804,7 @@ describe('paginate', () => {
         cat.home = catHomesClone
         delete cat.home.cat
 
-        expect(result.meta.search).toStrictEqual('Garfield')
+        expect(result.meta.search.query).toStrictEqual('Garfield')
         expect(result.data).toStrictEqual([cat])
         expect(result.data[0].home).toBeDefined()
         expect(result.data[0].home.pillows).toStrictEqual(cat.home.pillows)
@@ -837,7 +837,7 @@ describe('paginate', () => {
         cat.home = catHomesClone
         delete cat.home.cat
 
-        expect(result.meta.search).toStrictEqual('Garfield')
+        expect(result.meta.search.query).toStrictEqual('Garfield')
         expect(result.data).toStrictEqual([cat])
         expect(result.data[0].home).toBeDefined()
         expect(result.data[0].home.pillows).toStrictEqual(cat.home.pillows)
@@ -876,10 +876,10 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual(searchTerm)
-        expect(result.meta.searchBy).toStrictEqual(['color'])
+        expect(result.meta.search.query).toStrictEqual(searchTerm)
+        expect(result.meta.search.fields).toStrictEqual(['color'])
         expect(result.data).toStrictEqual(expectedResultData)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=white&searchBy=color')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=white&@search[fields]=color')
     })
 
     it('should return result based on where config and filter', async () => {
@@ -906,7 +906,7 @@ describe('paginate', () => {
         })
 
         expect(result.data).toStrictEqual([cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$not:Leche')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[name]=$not:Leche')
     })
 
     it('should return based on a nested many-to-one where condition', async () => {
@@ -925,11 +925,11 @@ describe('paginate', () => {
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
 
-        expect(result.meta.totalItems).toBe(3)
+        expect(result.meta.page.totalItems).toBe(3)
         result.data.forEach((toy) => {
             expect(toy.cat.id).toBe(cats[0].id)
         })
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should return valid data filtering by not id field many-to-one', async () => {
@@ -947,12 +947,12 @@ describe('paginate', () => {
         }
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
-
-        expect(result.meta.totalItems).toBe(3)
+        
+        expect(result.meta.page.totalItems).toBe(3)
         result.data.forEach((toy) => {
             expect(toy.cat.id).toBe(cats[0].id)
         })
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should return result based on where one-to-many relation', async () => {
@@ -1050,7 +1050,7 @@ describe('paginate', () => {
             'cat.name': '$not:Milo',
         })
         expect(result.data).toStrictEqual([catToys[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.name=$not:Milo')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.name]=$not:Milo')
     })
 
     it('should be possible to filter by relation without loading it', async () => {
@@ -1145,7 +1145,7 @@ describe('paginate', () => {
             'toys.name': '$not:Stuffed Mouse',
         })
         expect(result.data).toStrictEqual([cat1, cat2])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.toys.name=$not:Stuffed Mouse')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[toys.name]=$not:Stuffed Mouse')
     })
 
     it('should return result based on filter on one-to-one relation', async () => {
@@ -1173,7 +1173,7 @@ describe('paginate', () => {
         catHomesClone.countCat = cats.filter((cat) => cat.id === catHomesClone.cat.id).length
 
         expect(result.data).toStrictEqual([catHomesClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.name=$not:Garfield')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.name]=$not:Garfield')
     })
 
     it('should return result based on $in filter on one-to-one relation', async () => {
@@ -1201,7 +1201,7 @@ describe('paginate', () => {
         catHomesClone.countCat = cats.filter((cat) => cat.id === catHomesClone.cat.id).length
 
         expect(result.data).toStrictEqual([catHomesClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.age=$in:4,6')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.age]=$in:4,6')
     })
 
     it('should return result based on $btw filter on one-to-one relation', async () => {
@@ -1229,7 +1229,7 @@ describe('paginate', () => {
         catHomesClone.countCat = cats.filter((cat) => cat.id === catHomesClone.cat.id).length
 
         expect(result.data).toStrictEqual([catHomesClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.age=$btw:6,10')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.age]=$btw:6,10')
     })
 
     it('should return result based on sort on embedded entity', async () => {
@@ -1249,7 +1249,7 @@ describe('paginate', () => {
 
         const orderedCats = [cats[4], cats[0], cats[2], cats[1], cats[3]]
         expect(result.data).toStrictEqual(orderedCats)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=size.height:ASC&sortBy=size.length:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=size.height,size.length')
     })
 
     it('should return result based on sort on embedded entity when other relations loaded', async () => {
@@ -1298,7 +1298,7 @@ describe('paginate', () => {
 
         expect(result.data).toStrictEqual(orderedCats)
         expect(result.links.current).toBe(
-            '?page=1&limit=20&sortBy=size.height:DESC&sortBy=size.length:DESC&sortBy=toys.(size.height):DESC'
+            '?page[number]=1&page[size]=20&sort=-size.height,-size.length,-toys.(size.height)'
         )
     })
 
@@ -1340,7 +1340,7 @@ describe('paginate', () => {
         ]
         expect(result.data).toStrictEqual(orderedCats)
         expect(result.links.current).toBe(
-            '?page=1&limit=20&sortBy=id:DESC&sortBy=toys.(size.height):ASC&sortBy=toys.(size.length):ASC'
+            '?page[number]=1&page[size]=20&sort=-id,toys.(size.height),toys.(size.length)'
         )
     })
 
@@ -1364,7 +1364,7 @@ describe('paginate', () => {
 
         expect(result.data).toStrictEqual(orderedToys)
         expect(result.links.current).toBe(
-            '?page=1&limit=20&sortBy=cat.(size.height):DESC&sortBy=cat.(size.length):DESC&sortBy=name:ASC'
+            '?page[number]=1&page[size]=20&sort=-cat.(size.height),-cat.(size.length),name'
         )
     })
 
@@ -1386,7 +1386,7 @@ describe('paginate', () => {
         orderedHomes[1].countCat = cats.filter((cat) => cat.id === orderedHomes[1].cat.id).length
 
         expect(result.data).toStrictEqual(orderedHomes)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=cat.(size.height):DESC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=-cat.(size.height)')
     })
 
     it('should return result based on search on embedded entity', async () => {
@@ -1402,7 +1402,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=10')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=10')
     })
 
     it('should return result based on search term on embedded entity when other relations loaded', async () => {
@@ -1418,14 +1418,14 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('10')
+        expect(result.meta.search.query).toStrictEqual('10')
 
         const copyCat = clone(cats[4])
         copyCat.home = null
         copyCat.toys = []
 
         expect(result.data).toStrictEqual([copyCat])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=10')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=10')
     })
 
     it('should return result based on search term on embedded entity on many-to-one relation', async () => {
@@ -1440,9 +1440,9 @@ describe('paginate', () => {
         }
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
-        expect(result.meta.search).toStrictEqual('30')
+        expect(result.meta.search.query).toStrictEqual('30')
         expect(result.data).toStrictEqual([catToys[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=30')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=30')
     })
 
     it('should return result based on search term on embedded entity on one-to-many relation', async () => {
@@ -1468,7 +1468,7 @@ describe('paginate', () => {
             Object.assign(clone(cats[0]), { toys: [toy0] }),
             Object.assign(clone(cats[1]), { toys: [toy3] }),
         ])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=1')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=1')
     })
 
     it('should return result based on search term on embedded entity on one-to-one relation', async () => {
@@ -1486,7 +1486,7 @@ describe('paginate', () => {
         const catHomeClone = clone(catHomes[1])
         catHomeClone.countCat = cats.filter((cat) => cat.id === catHomeClone.cat.id).length
         expect(result.data).toStrictEqual([catHomeClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=30')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&@search[query]=30')
     })
 
     it('should return result based on sort and search on embedded many-to-one relation', async () => {
@@ -1502,14 +1502,14 @@ describe('paginate', () => {
         }
 
         const result = await paginate<CatToyEntity>(query, catToyRepo, config)
-        expect(result.meta.search).toStrictEqual('1')
+        expect(result.meta.search.query).toStrictEqual('1')
         expect(result.data).toStrictEqual([
             catToysWithoutShop[3],
             catToysWithoutShop[0],
             catToysWithoutShop[1],
             catToysWithoutShop[2],
         ])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=cat.(size.height):DESC&search=1')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=-cat.(size.height)&@search[query]=1')
     })
 
     it('should return result based on filter on embedded entity', async () => {
@@ -1530,7 +1530,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[1], cats[3], cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.size.height=$not:25')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[size.height]=$not:25')
     })
 
     it('should return result based on filter on embedded entity when other relations loaded', async () => {
@@ -1562,7 +1562,7 @@ describe('paginate', () => {
         ]
 
         expect(result.data).toStrictEqual(copyCats)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.size.height=$not:25')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[size.height]=$not:25')
     })
 
     it('should return result based on filter on embedded on many-to-one relation', async () => {
@@ -1586,7 +1586,7 @@ describe('paginate', () => {
             'cat.(size.height)': '$not:25',
         })
         expect(result.data).toStrictEqual([catToys[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.(size.height)=$not:25')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.(size.height)]=$not:25')
     })
 
     it('should return result based on filter on embedded on one-to-many relation', async () => {
@@ -1615,7 +1615,7 @@ describe('paginate', () => {
             'toys.(size.height)': '1',
         })
         expect(result.data).toStrictEqual([cat2])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.toys.(size.height)=1')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[toys.(size.height)]=1')
     })
 
     it('should return result based on filter on embedded on one-to-one relation', async () => {
@@ -1641,7 +1641,7 @@ describe('paginate', () => {
         const catClone = clone(catHomes[1])
         catClone.countCat = cats.filter((cat) => cat.size.height === 30 && cat.id == catClone.cat.id).length
         expect(result.data).toStrictEqual([catClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.(size.height)=$eq:30')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.(size.height)]=$eq:30')
     })
 
     it('should return result based on $in filter on embedded on one-to-one relation', async () => {
@@ -1671,7 +1671,9 @@ describe('paginate', () => {
                 cat.id == catClone.cat.id
         ).length
         expect(result.data).toStrictEqual([catClone])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.(size.height)=$in:10,30,35')
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&filter[cat.(size.height)]=$in:10,30,35'
+        )
     })
 
     it('should return result based on $btw filter on embedded on one-to-one relation', async () => {
@@ -1703,7 +1705,7 @@ describe('paginate', () => {
             (cat) => cat.size.height >= 18 && cat.size.height <= 33 && cat.id == catHomeClone[1].cat.id
         ).length
         expect(result.data).toStrictEqual([catHomeClone[0], catHomeClone[1]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.cat.(size.height)=$btw:18,33')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[cat.(size.height)]=$btw:18,33')
     })
 
     it('should return result based on where array and filter', async () => {
@@ -1734,7 +1736,7 @@ describe('paginate', () => {
             name: '$not:Leche',
         })
         expect(result.data).toStrictEqual([cats[2], cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$not:Leche')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[name]=$not:Leche')
     })
 
     it('should return result based on multiple filter', async () => {
@@ -1760,7 +1762,9 @@ describe('paginate', () => {
             color: 'white',
         })
         expect(result.data).toStrictEqual([cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$not:Leche&filter.color=white')
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&filter[name]=$not:Leche&filter[color]=white'
+        )
     })
 
     it('should return result based on $ilike filter', async () => {
@@ -1783,7 +1787,7 @@ describe('paginate', () => {
             name: '$ilike:arf',
         })
         expect(result.data).toStrictEqual([cats[1]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$ilike:arf')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[name]=$ilike:arf')
     })
 
     it('should return result based on $sw filter', async () => {
@@ -1806,7 +1810,7 @@ describe('paginate', () => {
             name: '$sw:Ga',
         })
         expect(result.data).toStrictEqual([cats[1]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.name=$sw:Ga')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[name]=$sw:Ga')
     })
 
     it('should return result based on filter and search term', async () => {
@@ -1827,10 +1831,12 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.search).toStrictEqual('white')
+        expect(result.meta.search.query).toStrictEqual('white')
         expect(result.meta.filter).toStrictEqual({ id: '$not:$in:1,2,5' })
         expect(result.data).toStrictEqual([cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&search=white&filter.id=$not:$in:1,2,5')
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&@search[query]=white&filter[id]=$not:$in:1,2,5'
+        )
     })
 
     it('should return result based on filter and where config', async () => {
@@ -1853,7 +1859,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[2], cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.id=$not:$in:1,2,5')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[id]=$not:$in:1,2,5')
     })
 
     it('should return result based on range filter', async () => {
@@ -1873,7 +1879,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[0], cats[1], cats[2]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$gte:4')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$gte:4')
     })
 
     it('should return result based on between range filter', async () => {
@@ -1893,7 +1899,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[1], cats[2]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$btw:4,5')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$btw:4,5')
     })
 
     it('should return result based on is null query', async () => {
@@ -1913,7 +1919,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$null')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$null')
     })
 
     it('should return result based on not null query', async () => {
@@ -1933,7 +1939,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[0], cats[1], cats[2], cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$not:$null')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$not:$null')
     })
 
     it('should return result based on not null query on relation', async () => {
@@ -1959,7 +1965,7 @@ describe('paginate', () => {
         })
 
         expect(result.data).toStrictEqual(expectedResult)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.name=$not:$null')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[home.name]=$not:$null')
     })
 
     it('should ignore filterable column which is not configured', async () => {
@@ -1979,7 +1985,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual(cats)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$not:$null')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$not:$null')
     })
 
     it('should ignore filter operator which is not configured', async () => {
@@ -1999,7 +2005,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual(cats)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$not:$null')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[age]=$not:$null')
     })
 
     it('should throw an error when no sortableColumns', async () => {
@@ -2122,7 +2128,9 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[0], cats[1], cats[2]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.age=$btw:4,5&filter.age=$or:$btw:5,6')
+        expect(result.links.current).toBe(
+            '?page[number]=1&page[size]=20&sort=id&filter[age]=$btw:4,5&filter[age]=$or:$btw:5,6'
+        )
     })
 
     it('should return result based on or with all cats', async () => {
@@ -2142,7 +2150,7 @@ describe('paginate', () => {
 
         expect(result.data).toStrictEqual([...cats])
         expect(result.links.current).toBe(
-            '?page=1&limit=20&sortBy=id:ASC&filter.age=$null&filter.age=$or:$not:$eq:$null'
+            '?page[number]=1&page[size]=20&sort=id&filter[age]=$null&filter[age]=$or:$not:$eq:$null'
         )
     })
 
@@ -2186,7 +2194,7 @@ describe('paginate', () => {
 
         expect(result.data).toStrictEqual(cats)
         expect(result.meta.select).toStrictEqual(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should return all items even if deleted', async () => {
@@ -2199,7 +2207,7 @@ describe('paginate', () => {
         }
         await catRepo.softDelete({ id: cats[0].id })
         const result = await paginate<CatEntity>(query, catRepo, config)
-        expect(result.meta.totalItems).toBe(cats.length)
+        expect(result.meta.page.totalItems).toBe(cats.length)
         await catRepo.restore({ id: cats[0].id })
     })
 
@@ -2213,7 +2221,7 @@ describe('paginate', () => {
         }
         await catRepo.softDelete({ id: cats[0].id })
         const result = await paginate<CatEntity>(query, catRepo, config)
-        expect(result.meta.totalItems).toBe(cats.length - 1)
+        expect(result.meta.page.totalItems).toBe(cats.length - 1)
         await catRepo.restore({ id: cats[0].id })
     })
 
@@ -2234,7 +2242,7 @@ describe('paginate', () => {
             expect(cat.color).not.toBeDefined()
         })
         expect(result.meta.select).toBe(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should ignore query select', async () => {
@@ -2254,7 +2262,7 @@ describe('paginate', () => {
             expect(cat.color).toBeDefined()
         })
         expect(result.meta.select).toEqual(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should only query select columns which have been config selected', async () => {
@@ -2276,7 +2284,7 @@ describe('paginate', () => {
             expect(cat.age).not.toBeDefined()
         })
         expect(result.meta.select).toEqual(['id', 'color'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,color')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&select=id,color')
     })
 
     it('should return the specified relationship columns only', async () => {
@@ -2302,7 +2310,7 @@ describe('paginate', () => {
             })
         })
         expect(result.meta.select).toBe(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=name:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=name')
     })
 
     it('should return selected columns', async () => {
@@ -2334,7 +2342,7 @@ describe('paginate', () => {
             }
         })
         expect(result.meta.select).toStrictEqual(['id', 'toys.(size.height)'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,toys.(size.height)')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&select=id,toys.(size.height)')
     })
 
     it('should only select columns via query which are selected in config', async () => {
@@ -2361,7 +2369,7 @@ describe('paginate', () => {
             }
         })
         expect(result.meta.select).toStrictEqual(['id', 'home.id'])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,home.id')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&select=id,home.id')
     })
 
     it('should return the specified nested relationship columns only', async () => {
@@ -2394,7 +2402,7 @@ describe('paginate', () => {
             }
         })
         expect(result.meta.select).toBe(undefined)
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id')
     })
 
     it('should return the right amount of results if a many to many relation is involved', async () => {
@@ -2409,7 +2417,7 @@ describe('paginate', () => {
 
         const result = await paginate<CatEntity>(query, catRepo, config)
 
-        expect(result.meta.totalItems).toBe(5)
+        expect(result.meta.page.totalItems).toBe(5)
         expect(result.data.length).toBe(5)
         expect(result.data[0].friends.length).toBe(4)
     })
@@ -2457,7 +2465,7 @@ describe('paginate', () => {
         cat.home = catHomesClone
         delete cat.home.cat
 
-        expect(result.meta.search).toStrictEqual('pink')
+        expect(result.meta.search.query).toStrictEqual('pink')
         expect(result.data).toStrictEqual([cat])
         expect(result.data[0].home).toBeDefined()
         expect(result.data[0].home.pillows).toStrictEqual(cat.home.pillows)
@@ -2509,7 +2517,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[2], cats[3]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.id=$not:$in:1,2,5')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[id]=$not:$in:1,2,5')
     })
 
     it('should ignore all filters on a field when not passing anything', async () => {
@@ -2526,7 +2534,7 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
 
         expect(result.data).toStrictEqual([cats[0], cats[1], cats[2], cats[3], cats[4]])
-        expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.id=$not:$in:1,2,5')
+        expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[id]=$not:$in:1,2,5')
     })
 
     it('should use searchBy in query param when ignoreSearchByInQueryParam is not defined', async () => {
@@ -2654,7 +2662,7 @@ describe('paginate', () => {
                 lastVetVisit: '$not:$null',
             })
             expect(result.data).toStrictEqual([cats[0], cats[1], cats[2]])
-            expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$not:$null')
+            expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$not:$null')
         })
 
         it('with $lt operator', async () => {
@@ -2678,7 +2686,7 @@ describe('paginate', () => {
             })
             expect(result.data).toStrictEqual([cats[0]])
             expect(result.links.current).toBe(
-                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lt:2022-12-20T10:00:00.000Z'
+                '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$lt:2022-12-20T10:00:00.000Z'
             )
         })
 
@@ -2703,7 +2711,7 @@ describe('paginate', () => {
             })
             expect(result.data).toStrictEqual([cats[0], cats[1]])
             expect(result.links.current).toBe(
-                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lte:2022-12-20T10:00:00.000Z'
+                '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$lte:2022-12-20T10:00:00.000Z'
             )
         })
 
@@ -2728,7 +2736,7 @@ describe('paginate', () => {
             })
             expect(result.data).toStrictEqual([cats[1]])
             expect(result.links.current).toBe(
-                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$btw:2022-12-20T08:00:00.000Z,2022-12-20T12:00:00.000Z'
+                '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$btw:2022-12-20T08:00:00.000Z,2022-12-20T12:00:00.000Z'
             )
         })
 
@@ -2753,7 +2761,7 @@ describe('paginate', () => {
             })
             expect(result.data).toStrictEqual([cats[1], cats[2]])
             expect(result.links.current).toBe(
-                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$gte:2022-12-20T10:00:00.000Z'
+                '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$gte:2022-12-20T10:00:00.000Z'
             )
         })
 
@@ -2778,7 +2786,7 @@ describe('paginate', () => {
             })
             expect(result.data).toStrictEqual([cats[2]])
             expect(result.links.current).toBe(
-                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$gt:2022-12-20T10:00:00.000Z'
+                '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$gt:2022-12-20T10:00:00.000Z'
             )
         })
 
@@ -2803,7 +2811,9 @@ describe('paginate', () => {
                     lastVetVisit: '$lt:2022-12-20',
                 })
                 expect(result.data).toStrictEqual([cats[0]])
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lt:2022-12-20')
+                expect(result.links.current).toBe(
+                    '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$lt:2022-12-20'
+                )
             }
             {
                 const config: PaginateConfig<CatEntity> = {
@@ -2825,7 +2835,9 @@ describe('paginate', () => {
                     lastVetVisit: '$lt:2022-12-21',
                 })
                 expect(result.data).toStrictEqual([cats[0], cats[1]])
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lt:2022-12-21')
+                expect(result.links.current).toBe(
+                    '?page[number]=1&page[size]=20&sort=id&filter[lastVetVisit]=$lt:2022-12-21'
+                )
             }
         })
     })
@@ -2906,7 +2918,7 @@ describe('paginate', () => {
                 const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
 
                 expect(result.data).toStrictEqual([catHomes[0], catHomes[1]])
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=countCat:ASC&filter.countCat=$gt:0')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=countCat&filter[countCat]=$gt:0')
             })
 
             it('should return result based on virtual column filter', async () => {
@@ -2933,7 +2945,7 @@ describe('paginate', () => {
                 })
 
                 expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.countCat=$gt:0')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[home.countCat]=$gt:0')
             })
 
             it('should return result sorted by a virtual column', async () => {
@@ -2960,7 +2972,7 @@ describe('paginate', () => {
                 })
 
                 expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=home.countCat')
             })
 
             it('should return result sorted and filter by a virtual column in main entity', async () => {
@@ -2982,7 +2994,7 @@ describe('paginate', () => {
                 const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
 
                 expect(result.data).toStrictEqual([catHomes[0], catHomes[1]])
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=countCat:ASC&filter.countCat=$gt:0')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=countCat&filter[countCat]=$gt:0')
             })
 
             it('should return result based on virtual column filter', async () => {
@@ -3009,7 +3021,7 @@ describe('paginate', () => {
                 })
 
                 expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.countCat=$gt:0')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=id&filter[home.countCat]=$gt:0')
             })
 
             it('should return result sorted by a virtual column', async () => {
@@ -3036,7 +3048,7 @@ describe('paginate', () => {
                 })
 
                 expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
+                expect(result.links.current).toBe('?page[number]=1&page[size]=20&sort=home.countCat')
             })
         })
     }

--- a/src/swagger/paginated-swagger.type.ts
+++ b/src/swagger/paginated-swagger.type.ts
@@ -39,13 +39,20 @@ class PaginatedLinksDocumented {
     last?: string
 }
 
-export class PaginatedMetaDocumented<T> {
+class PaginatedPageDocumented {
+    @ApiProperty({
+        title: 'Number of the page',
+        required: true,
+        type: 'number',
+    })
+    number!: number
+
     @ApiProperty({
         title: 'Number of items per page',
         required: true,
         type: 'number',
     })
-    itemsPerPage!: number
+    size!: number
 
     @ApiProperty({
         title: 'Total number of items',
@@ -55,54 +62,51 @@ export class PaginatedMetaDocumented<T> {
     totalItems!: number
 
     @ApiProperty({
-        title: 'Current requested page',
-        required: true,
-        type: 'number',
-    })
-    currentPage!: number
-
-    @ApiProperty({
         title: 'Total number of pages',
         required: true,
         type: 'number',
     })
     totalPages!: number
+}
 
+class PaginatedSearchDocumented<T> {
     @ApiProperty({
-        title: 'Sorting by columns',
-        required: false,
-        type: 'array',
-        items: {
-            type: 'array',
-            items: {
-                oneOf: [
-                    {
-                        type: 'string',
-                    },
-                    {
-                        type: 'string',
-                        enum: ['ASC', 'DESC'],
-                    },
-                ],
-            },
-        },
-    })
-    sortBy!: SortBy<T>
-
-    @ApiProperty({
-        title: 'Search by fields',
+        title: 'Search fields',
         required: false,
         isArray: true,
         type: 'string',
     })
-    searchBy!: Column<T>[]
+    fields!: Column<T>[]
 
     @ApiProperty({
         title: 'Search term',
         required: false,
         type: 'string',
     })
-    search!: string
+    query!: string
+}
+
+export class PaginatedMetaDocumented<T> {
+    @ApiProperty({
+        title: 'Page query',
+        required: true,
+        type: 'object',
+    })
+    page!: PaginatedPageDocumented
+
+    @ApiProperty({
+        title: 'Sort query',
+        required: false,
+        type: 'string',
+    })
+    sort!: string
+
+    @ApiProperty({
+        title: 'Search query',
+        required: false,
+        type: 'string',
+    })
+    search!: PaginatedSearchDocumented<T>
 
     @ApiProperty({
         title: 'List of selected fields',

--- a/src/swagger/pagination-docs.spec.ts
+++ b/src/swagger/pagination-docs.spec.ts
@@ -68,36 +68,38 @@ describe('PaginatedEndpoint decorator', () => {
         const params = openApiDefinition.paths['/test'].get.parameters
         expect(params).toStrictEqual([
             {
-                name: 'page',
+                name: 'page[number]',
                 required: false,
                 in: 'query',
                 description:
-                    'Page number to retrieve.If you provide invalid value the default page number will applied\n        <p>\n             <b>Example: </b> 1\n          </p>\n        <p>\n             <b>Default Value: </b> 1\n          </p>\n        ',
+                    'Page number to retrieve. If you provide an invalid value the default page number will applied.\n        <p>\n             <b>Example: </b> 1\n          </p>\n        <p>\n             <b>Default Value: </b> 1\n          </p>\n        ',
                 schema: {
                     type: 'number',
                 },
             },
             {
-                name: 'limit',
+                name: 'page[size]',
                 required: false,
                 in: 'query',
                 description:
-                    'Number of records per page.\n      <p>\n             <b>Example: </b> 20\n          </p>\n      <p>\n             <b>Default Value: </b> 20\n          </p>\n      <p>\n             <b>Max Value: </b> 100\n          </p>\n\n      If provided value is greater than max value, max value will be applied.\n      ',
+                    'Number of records per page.\n      <p>\n             <b>Example: </b> 20\n          </p>\n      <p>\n             <b>Default Value: </b> 20\n          </p>\n      <p>\n             <b>Max Value: </b> 100\n          </p>\n\n      If the provided value is greater than the maximum value, the maximum value will be applied.\n      ',
                 schema: {
                     type: 'number',
                 },
             },
             {
-                name: 'sortBy',
+                name: 'sort',
                 required: false,
                 in: 'query',
+                explode: false,
+                style: 'form',
                 description:
-                    'Parameter to sort by.\n      <p>To sort by multiple fields, just provide query param multiple types. The order in url defines an order of sorting</p>\n      <p>\n             <b>Format: </b> fieldName:DIRECTION\n          </p>\n      <p>\n             <b>Example: </b> sortBy=id:DESC&sortBy=createdAt:ASC\n          </p>\n      <p>\n             <b>Default Value: </b> No default sorting specified, the result order is not guaranteed\n          </p>\n      <h4>Available Fields</h4><ul><li>id</li></ul>\n      ',
+                    'Comma separated list of field names to sort by. Add a minus to use a field name for a descending sort.\n      <p>\n             <b>Format: </b> fieldName OR -fieldName\n          </p>\n      <p>\n             <b>Example: </b> sort=-id,createdAt\n          </p>\n      <p>\n             <b>Default Value: </b> No default sorting specified, the result order is not guaranteed\n          </p>\n      <h4>Available Fields</h4><ul><li>id</li></ul>\n      ',
                 schema: {
                     type: 'array',
                     items: {
                         type: 'string',
-                        enum: ['id:ASC', 'id:DESC'],
+                        enum: ['id', '-id'],
                     },
                 },
             },
@@ -150,31 +152,31 @@ describe('PaginatedEndpoint decorator', () => {
         const params = openApiDefinition.paths['/test'].get.parameters
         expect(params).toStrictEqual([
             {
-                name: 'page',
+                name: 'page[number]',
                 required: false,
                 in: 'query',
                 description:
-                    'Page number to retrieve.If you provide invalid value the default page number will applied\n        <p>\n             <b>Example: </b> 1\n          </p>\n        <p>\n             <b>Default Value: </b> 1\n          </p>\n        ',
+                    'Page number to retrieve. If you provide an invalid value the default page number will applied.\n        <p>\n             <b>Example: </b> 1\n          </p>\n        <p>\n             <b>Default Value: </b> 1\n          </p>\n        ',
                 schema: {
                     type: 'number',
                 },
             },
             {
-                name: 'limit',
+                name: 'page[size]',
                 required: false,
                 in: 'query',
                 description:
-                    'Number of records per page.\n      <p>\n             <b>Example: </b> 20\n          </p>\n      <p>\n             <b>Default Value: </b> 20\n          </p>\n      <p>\n             <b>Max Value: </b> 100\n          </p>\n\n      If provided value is greater than max value, max value will be applied.\n      ',
+                    'Number of records per page.\n      <p>\n             <b>Example: </b> 20\n          </p>\n      <p>\n             <b>Default Value: </b> 20\n          </p>\n      <p>\n             <b>Max Value: </b> 100\n          </p>\n\n      If the provided value is greater than the maximum value, the maximum value will be applied.\n      ',
                 schema: {
                     type: 'number',
                 },
             },
             {
-                name: 'filter.id',
+                name: 'filter[id]',
                 required: false,
                 in: 'query',
                 description:
-                    'Filter by id query param.\n          <p>\n             <b>Format: </b> filter.id={$not}:OPERATION:VALUE\n          </p>\n          <p>\n             <b>Example: </b> filter.id=$not:$like:John Doe&filter.id=like:John\n          </p>\n          <h4>Available Operations</h4><ul><li>$and</li>\n<li>$or</li>\n<li>$not</li>\n<li>$eq</li>\n<li>$gt</li>\n<li>$gte</li>\n<li>$in</li>\n<li>$null</li>\n<li>$lt</li>\n<li>$lte</li>\n<li>$btw</li>\n<li>$ilike</li>\n<li>$sw</li>\n<li>$contains</li></ul>',
+                    'Filter by id query param.\n          <p>\n             <b>Format: </b> filter[id]={$not}:OPERATION:VALUE\n          </p>\n          <p>\n             <b>Example: </b> filter[id]=$not:$like:John Doe&filter[id]=like:John\n          </p>\n          <h4>Available Operations</h4><ul><li>$and</li>\n<li>$or</li>\n<li>$not</li>\n<li>$eq</li>\n<li>$gt</li>\n<li>$gte</li>\n<li>$in</li>\n<li>$null</li>\n<li>$lt</li>\n<li>$lte</li>\n<li>$btw</li>\n<li>$ilike</li>\n<li>$sw</li>\n<li>$contains</li></ul>',
                 schema: {
                     type: 'array',
                     items: {
@@ -183,11 +185,11 @@ describe('PaginatedEndpoint decorator', () => {
                 },
             },
             {
-                name: 'filter.name',
+                name: 'filter[name]',
                 required: false,
                 in: 'query',
                 description:
-                    'Filter by name query param.\n          <p>\n             <b>Format: </b> filter.name={$not}:OPERATION:VALUE\n          </p>\n          <p>\n             <b>Example: </b> filter.name=$not:$like:John Doe&filter.name=like:John\n          </p>\n          <h4>Available Operations</h4><ul><li>$eq</li>\n<li>$not</li></ul>',
+                    'Filter by name query param.\n          <p>\n             <b>Format: </b> filter[name]={$not}:OPERATION:VALUE\n          </p>\n          <p>\n             <b>Example: </b> filter[name]=$not:$like:John Doe&filter[name]=like:John\n          </p>\n          <h4>Available Operations</h4><ul><li>$eq</li>\n<li>$not</li></ul>',
                 schema: {
                     type: 'array',
                     items: {
@@ -196,38 +198,42 @@ describe('PaginatedEndpoint decorator', () => {
                 },
             },
             {
-                name: 'sortBy',
+                name: 'sort',
                 required: false,
+                explode: false,
+                style: 'form',
                 in: 'query',
                 description:
-                    'Parameter to sort by.\n      <p>To sort by multiple fields, just provide query param multiple types. The order in url defines an order of sorting</p>\n      <p>\n             <b>Format: </b> fieldName:DIRECTION\n          </p>\n      <p>\n             <b>Example: </b> sortBy=id:DESC&sortBy=createdAt:ASC\n          </p>\n      <p>\n             <b>Default Value: </b> id:DESC\n          </p>\n      <h4>Available Fields</h4><ul><li>id</li></ul>\n      ',
+                    'Comma separated list of field names to sort by. Add a minus to use a field name for a descending sort.\n      <p>\n             <b>Format: </b> fieldName OR -fieldName\n          </p>\n      <p>\n             <b>Example: </b> sort=-id,createdAt\n          </p>\n      <p>\n             <b>Default Value: </b> -id\n          </p>\n      <h4>Available Fields</h4><ul><li>id</li></ul>\n      ',
                 schema: {
                     type: 'array',
                     items: {
                         type: 'string',
-                        enum: ['id:ASC', 'id:DESC'],
+                        enum: ['id', '-id'],
                     },
                 },
             },
             {
-                name: 'search',
+                name: '@search[query]',
                 required: false,
                 in: 'query',
                 description:
-                    'Search term to filter result values\n        <p>\n             <b>Example: </b> John\n          </p>\n        <p>\n             <b>Default Value: </b> No default value\n          </p>\n        ',
+                    'Search term to filter result values across all searchable fields.\n        <p>\n             <b>Example: </b> John\n          </p>\n        <p>\n             <b>Default Value: </b> No default value\n          </p>\n        ',
                 schema: {
                     type: 'string',
                 },
             },
             {
-                name: 'searchBy',
+                name: '@search[fields]',
                 required: false,
+                explode: false,
                 in: 'query',
                 description:
                     'List of fields to search by term to filter result values\n        <p>\n             <b>Example: </b> name\n          </p>\n        <p>\n             <b>Default Value: </b> By default all fields mentioned below will be used to search by term\n          </p>\n        <h4>Available Fields</h4><ul><li>name</li></ul>\n        ',
                 schema: {
                     type: 'array',
                     items: {
+                        enum: ['name'],
                         type: 'string',
                     },
                 },


### PR DESCRIPTION
Re-re-submit of #769 

---

This changeset implements the following syntactic changes:

* Change `page` to `page[number]`
* Change `limit` to `page[size]`
* Change `sortBy` to `sort`
* Change current syntax (`field:ASC/DESC`) to a comma separated ordered list of the sort fields with minus as desc operator (`field1,-field2`)
* Change `filter.field` to `filter[field]`
*  Change `search` to `@search[query]`
* Change `searchBy` to `@search[fields]`
* Allow `@search` as a shorthand for `@search[query]` (without the possibility to then specify fields)

The changeset tries to converge as soon as possible, so even though the syntax changed, none of these changes alters the produced `PaginateQuery`, or any code outside `decorator.ts`

---

It also refactored the parsing logic and the decorator tests. 

The parsers in many places allowed for an array notation (probably used as `select[0]=field1&select[1]=field2`), but this was undocumented and we now switch to strictly comma separated values as specified by JSON:API