### PR TITLE
Fix sql query for multifilter

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -322,8 +322,8 @@ export function addFilter<T>(
     const filter = parseFilter(query, filterableColumns)
 
     const filterEntries = Object.entries(filter)
-    const orFilters = filterEntries.filter(([_, value]) => value.some((v) => v.comparator === '$or'))
-    const andFilters = filterEntries.filter(([_, value]) => value.some((v) => v.comparator !== '$or'))
+    const orFilters = filterEntries.filter(([_, value]) => value[0].comparator === '$or')
+    const andFilters = filterEntries.filter(([_, value]) => value[0].comparator === '$and')
 
     qb.andWhere(
         new Brackets((qb: SelectQueryBuilder<T>) => {
@@ -333,13 +333,13 @@ export function addFilter<T>(
         })
     )
 
-    qb.andWhere(
-        new Brackets((qb: SelectQueryBuilder<T>) => {
-            for (const [column] of andFilters) {
+    for (const [column] of andFilters) {
+        qb.andWhere(
+            new Brackets((qb: SelectQueryBuilder<T>) => {
                 addWhereCondition(qb, column, filter)
-            }
-        })
-    )
+            })
+        )
+    }
 
     return qb
 }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -2328,7 +2328,8 @@ describe('paginate', () => {
         const result = await paginate<CatEntity>(query, catRepo, config)
         const expected = cats.filter(
             (cat) =>
-                (cat.name === 'Milo' || cat.name === 'Garfield' || !cat.age) && (cat.color === 'brown' || cat.color === 'white') &&
+                (cat.name === 'Milo' || cat.name === 'Garfield' || !cat.age) &&
+                (cat.color === 'brown' || cat.color === 'white') &&
                 (cat.cutenessLevel === CutenessLevel.HIGH || cat.cutenessLevel === CutenessLevel.LOW)
         )
         expect(result.data).toStrictEqual(expected)


### PR DESCRIPTION
There was a bug regarding multifilter.

The filters were split depending on whether they had an or operator or an and operator somewhere. However, multifilter may start with an and operator and have or operators inside. This meant that they were used twice and it also caused problems that an and operator binds stronger than an or operator.

Example: 
```node
filter: {
    name: ['Milo', '$or:Garfield'],
    color: ['brown', '$or:white'],
}
```
SQL Query: `... WHERE ( ("__root"."name" = "Milo" OR "__root"."name" = "Garfield" AND "__root"."color" = "brown" OR "__root"."color" = "white") AND ("__root"."name" = "Milo" OR "__root"."name" = "Garfield" AND "__root"."color" = "brown"  OR "__root"."color" = "white")`

(See: `... OR "__root"."name" = "Garfield" AND "__root"."color" = "brown" OR ...`)

Now in my changes the first operator of a filter is checked, so they are not used twice and also filters that starts with an and operators are put in extra brackets, since in the case of a multifilter they contain or operators and otherwise you would have problems again because of the stronger binding of an and operator.

Example:
```node
filter: {
    name: ['Milo', '$or:Garfield'],
    color: ['brown', '$or:white'],
}
```

SQL Query: `WHERE ( ("__root"."name" = "Milo" OR "__root"."name" = "Garfield") AND ("__root"."color" = "brown" OR "__root"."color" = "white") )`