### PR TITLE
Fix array contains fail when postgres because add cardinality

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -178,7 +178,7 @@ export function addWhereCondition<T>(qb: SelectQueryBuilder<T>, column: string, 
         const parameters = fixQueryParam(alias, columnNamePerIteration, columnFilter, condition, {
             [columnNamePerIteration]: columnFilter.findOperator.value,
         })
-        if (isArray && condition.parameters?.length && !['not', 'isNull'].includes(condition.operator)) {
+        if (isArray && condition.parameters?.length && !['not', 'isNull', 'arrayContains'].includes(condition.operator)) {
             condition.parameters[0] = `cardinality(${condition.parameters[0]})`
         }
         if (columnFilter.comparator === FilterComparator.OR) {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -178,7 +178,11 @@ export function addWhereCondition<T>(qb: SelectQueryBuilder<T>, column: string, 
         const parameters = fixQueryParam(alias, columnNamePerIteration, columnFilter, condition, {
             [columnNamePerIteration]: columnFilter.findOperator.value,
         })
-        if (isArray && condition.parameters?.length && !['not', 'isNull', 'arrayContains'].includes(condition.operator)) {
+        if (
+            isArray &&
+            condition.parameters?.length &&
+            !['not', 'isNull', 'arrayContains'].includes(condition.operator)
+        ) {
             condition.parameters[0] = `cardinality(${condition.parameters[0]})`
         }
         if (columnFilter.comparator === FilterComparator.OR) {

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3005,6 +3005,7 @@ describe('paginate', () => {
                 ${'$btw'}       | ${'1,2'}     | ${[1, 2]}
                 ${'$gte'}       | ${2}         | ${[0, 1]}
                 ${'$gt'}        | ${2}         | ${[0]}
+                ${'$contains'}  | ${'brown'}   | ${[0, 1]}
             `('with $operator operator', async ({ operator, data, expectedIndexes }) => {
                 const config: PaginateConfig<CatHairEntity> = {
                     sortableColumns: ['id'],


### PR DESCRIPTION
I want use filter `contains` at array column(postgres)
but error occured
```
QueryFailedError: operator does not exist: integer @> unknown
    at PostgresQueryRunner.query (/app/src/driver/postgres/PostgresQueryRunner.ts:299:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at SelectQueryBuilder.loadRawResults (/app/src/query-builder/SelectQueryBuilder.ts:3555:25)
    at SelectQueryBuilder.executeEntitiesAndRawResults (/app/src/query-builder/SelectQueryBuilder.ts:3320:26)
    at SelectQueryBuilder.getManyAndCount (/app/src/query-builder/SelectQueryBuilder.ts:1756:36)
    at paginate (/app/node_modules/nestjs-paginate/src/paginate.ts:353:32)
    at ManagerUserService.findAll (/app/src/manager/admin/user/manager-user.service.ts:62:20)
    at /app/node_modules/@nestjs/core/router/router-execution-context.js:46:28
    at /app/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

Adding cardinality should only be applied to operators related to case relationships, not ArrayContains.

relate issue
https://github.com/ppetzold/nestjs-paginate/issues/936

relate commit
https://github.com/ppetzold/nestjs-paginate/blame/1883c2d92f85740d87b3686cbb2ea3918a46f04c/src/filter.ts#L182