### PR TITLE
Enhanced Multi-Word Search Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * Description: Prevent `select` query param from limiting selection further. Partial selection will depend upon `select` config option only
    */
   ignoreSelectInQueryParam: true,
+
+  /**
+   * Required: false
+   * Type: boolean
+   * Default: false
+   * Description: Enable multi-word search behavior. When true, each word in the search query
+   * will be treated as a separate search term, allowing for more flexible matching.
+   */
+  multiWordSearch: false,
 }
 ```
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -90,7 +90,7 @@ export interface PaginateConfig<T> {
     origin?: string
     ignoreSearchByInQueryParam?: boolean
     ignoreSelectInQueryParam?: boolean
-    multiWordSearch?: boolean 
+    multiWordSearch?: boolean
 }
 
 export enum PaginationLimit {
@@ -354,7 +354,7 @@ export async function paginate<T extends ObjectLiteral>(
         queryBuilder.andWhere(
             new Brackets((qb: SelectQueryBuilder<T>) => {
                 // Explicitly handle the default case - multiWordSearch defaults to false
-                const useMultiWordSearch = config.multiWordSearch ?? false;
+                const useMultiWordSearch = config.multiWordSearch ?? false
                 if (!useMultiWordSearch) {
                     // Strict search mode (default behavior)
                     for (const column of searchBy) {
@@ -370,29 +370,32 @@ export async function paginate<T extends ObjectLiteral>(
                             isEmbedded,
                             virtualQuery
                         )
-    
+
                         const condition: WherePredicateOperator = {
                             operator: 'ilike',
                             parameters: [alias, `:${property.column}`],
                         }
-    
+
                         if (['postgres', 'cockroachdb'].includes(queryBuilder.connection.options.type)) {
                             condition.parameters[0] = `CAST(${condition.parameters[0]} AS text)`
                         }
-    
+
                         qb.orWhere(qb['createWhereConditionExpression'](condition), {
                             [property.column]: `%${query.search}%`,
                         })
                     }
                 } else {
                     // Multi-word search mode
-                    const searchWords = query.search.split(' ').filter(word => word.length > 0)
+                    const searchWords = query.search.split(' ').filter((word) => word.length > 0)
                     searchWords.forEach((searchWord, index) => {
                         qb.andWhere(
                             new Brackets((subQb: SelectQueryBuilder<T>) => {
                                 for (const column of searchBy) {
                                     const property = getPropertiesByColumnName(column)
-                                    const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(subQb, property)
+                                    const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(
+                                        subQb,
+                                        property
+                                    )
                                     const isRelation = checkIsRelation(subQb, property.propertyPath)
                                     const isEmbedded = checkIsEmbedded(subQb, property.propertyPath)
                                     const alias = fixColumnAlias(
@@ -403,16 +406,16 @@ export async function paginate<T extends ObjectLiteral>(
                                         isEmbedded,
                                         virtualQuery
                                     )
-    
+
                                     const condition: WherePredicateOperator = {
                                         operator: 'ilike',
                                         parameters: [alias, `:${property.column}_${index}`],
                                     }
-    
+
                                     if (['postgres', 'cockroachdb'].includes(queryBuilder.connection.options.type)) {
                                         condition.parameters[0] = `CAST(${condition.parameters[0]} AS text)`
                                     }
-    
+
                                     subQb.orWhere(subQb['createWhereConditionExpression'](condition), {
                                         [`${property.column}_${index}`]: `%${searchWord}%`,
                                     })

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -90,7 +90,7 @@ export interface PaginateConfig<T> {
     origin?: string
     ignoreSearchByInQueryParam?: boolean
     ignoreSelectInQueryParam?: boolean
-    multiWordSearch?: boolean // New property to control multi-word search behavior
+    multiWordSearch?: boolean 
 }
 
 export enum PaginationLimit {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -90,7 +90,7 @@ export interface PaginateConfig<T> {
     origin?: string
     ignoreSearchByInQueryParam?: boolean
     ignoreSelectInQueryParam?: boolean
-    strictSearch?: boolean // New property to control search mode
+    multiWordSearch?: boolean // New property to control multi-word search behavior
 }
 
 export enum PaginationLimit {
@@ -353,7 +353,9 @@ export async function paginate<T extends ObjectLiteral>(
     if (query.search && searchBy.length) {
         queryBuilder.andWhere(
             new Brackets((qb: SelectQueryBuilder<T>) => {
-                if (!config.multiWordSearch) {
+                // Explicitly handle the default case - multiWordSearch defaults to false
+                const useMultiWordSearch = config.multiWordSearch ?? false;
+                if (!useMultiWordSearch) {
                     // Strict search mode (default behavior)
                     for (const column of searchBy) {
                         const property = getPropertiesByColumnName(column)


### PR DESCRIPTION
## Description
This PR introduces an enhancement to the search functionality in the paginate function, allowing for more flexible and powerful searches across multiple columns.
## Changes Made

- Modified the search logic in the paginate function to split the search query into individual words.
- Implemented a nested Brackets structure to apply each word across all searchable columns.
- Used AND conditions between different words and OR conditions between columns for each word.
- Maintained type casting for PostgreSQL and CockroachDB to ensure compatibility.

## Motivation
This change addresses a user-reported limitation where searching for multiple words or IDs in the same query was not possible. The new implementation allows for more natural search queries that can include multiple words and numeric IDs, searching across all specified columns.
## Usage Example
With this change, a search query like "John Doe 123" will match records where:

- "John" appears in any searchable column, AND
- "Doe" appears in any searchable column, AND
- "123" appears in any searchable column

This is particularly useful for scenarios where users want to search for names and IDs in the same query.

addressese issue #918 