### PR TITLE
Avoid number casting on number values that contain non-digit characters

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -116,7 +116,7 @@ export function getPropertiesByColumnName(column: string): ColumnProperties {
 export function extractVirtualProperty(
     qb: SelectQueryBuilder<unknown>,
     columnProperties: ColumnProperties
-): { isVirtualProperty: boolean; query?: ColumnMetadata['query'] } {
+): Partial<Omit<ColumnMetadata, 'isVirtualProperty'>> & { isVirtualProperty: ColumnMetadata['isVirtualProperty'] } {
     const metadata = columnProperties.propertyPath
         ? qb?.expressionMap?.mainAlias?.metadata?.findColumnWithPropertyPath(columnProperties.propertyPath)
               ?.referencedColumn?.entityMetadata // on relation

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -2897,6 +2897,31 @@ describe('paginate', () => {
             )
         })
 
+        it('with $eq operator', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id'],
+                filterableColumns: {
+                    lastVetVisit: [FilterOperator.EQ],
+                },
+            }
+            const query: PaginateQuery = {
+                path: '',
+                filter: {
+                    lastVetVisit: '$eq:2022-12-21T10:00:00.000Z',
+                },
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            expect(result.meta.filter).toStrictEqual({
+                lastVetVisit: '$eq:2022-12-21T10:00:00.000Z',
+            })
+            expect(result.data).toStrictEqual([cats[2]])
+            expect(result.links.current).toBe(
+                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$eq:2022-12-21T10:00:00.000Z'
+            )
+        })
+
         it('with $gte operator', async () => {
             const config: PaginateConfig<CatEntity> = {
                 sortableColumns: ['id'],
@@ -2992,6 +3017,33 @@ describe('paginate', () => {
                 expect(result.data).toStrictEqual([cats[0], cats[1]])
                 expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lt:2022-12-21')
             }
+        })
+    })
+
+    describe('should correctly handle number column filter', () => {
+        it('with $eq operator and valid number', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id'],
+                filterableColumns: {
+                    lastVetVisit: [FilterOperator.LT],
+                },
+            }
+            const query: PaginateQuery = {
+                path: '',
+                filter: {
+                    lastVetVisit: '$lt:2022-12-20T10:00:00.000Z',
+                },
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            expect(result.meta.filter).toStrictEqual({
+                lastVetVisit: '$lt:2022-12-20T10:00:00.000Z',
+            })
+            expect(result.data).toStrictEqual([cats[0]])
+            expect(result.links.current).toBe(
+                '?page=1&limit=20&sortBy=id:ASC&filter.lastVetVisit=$lt:2022-12-20T10:00:00.000Z'
+            )
         })
     })
 


### PR DESCRIPTION
Fixes #1000 by adding an additional check: `/^\d+$/.test(value)`

I also took the liberty of pulling out the function and (hopefully) increasing readability

I haven't had a chance to test this with real-world data, but I'm hoping there might be integration / unit tests verifying that the updated code works. If not, happy to do some manual tested if needed.