### PR TITLE
feat: add cursor pagination

### DIFF
--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -108,6 +108,9 @@ describe('Decorator', () => {
             searchBy: undefined,
             filter: undefined,
             select: undefined,
+            cursor: undefined,
+            cursorColumn: undefined,
+            cursorDirection: undefined,
             path: 'http://localhost/items',
         })
     })
@@ -125,6 +128,9 @@ describe('Decorator', () => {
             searchBy: undefined,
             filter: undefined,
             select: undefined,
+            cursor: undefined,
+            cursorColumn: undefined,
+            cursorDirection: undefined,
             path: 'http://localhost/items',
         })
     })
@@ -138,6 +144,9 @@ describe('Decorator', () => {
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
             select: ['name', 'createdAt'],
+            cursor: 'abc123',
+            cursorColumn: 'id',
+            cursorDirection: 'after',
         })
 
         const result: PaginateQuery = decoratorfactory(null, context)
@@ -157,6 +166,9 @@ describe('Decorator', () => {
                 name: '$not:$eq:Kitty',
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
+            cursor: 'abc123',
+            cursorColumn: 'id',
+            cursorDirection: 'after',
         })
     })
 
@@ -169,6 +181,9 @@ describe('Decorator', () => {
             'filter.name': '$not:$eq:Kitty',
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
             select: ['name', 'createdAt'],
+            cursor: 'abc123',
+            cursorColumn: 'id',
+            cursorDirection: 'after',
         })
 
         const result: PaginateQuery = decoratorfactory(null, context)
@@ -188,6 +203,9 @@ describe('Decorator', () => {
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
             select: ['name', 'createdAt'],
+            cursor: 'abc123',
+            cursorColumn: 'id',
+            cursorDirection: 'after',
         })
     })
 })

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -19,6 +19,9 @@ export interface PaginateQuery {
     search?: string
     filter?: { [column: string]: string | string[] }
     select?: string[]
+    cursor?: string
+    cursorColumn?: string
+    cursorDirection?: 'before' | 'after'
     path: string
 }
 
@@ -101,6 +104,10 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
         searchBy,
         filter: Object.keys(filter).length ? filter : undefined,
         select,
+        cursor: query.cursor ? query.cursor.toString() : undefined,
+        cursorColumn: query.cursorColumn ? query.cursorColumn.toString() : undefined,
+        cursorDirection:
+            query.cursorDirection === 'after' || query.cursorDirection === 'before' ? query.cursorDirection : undefined,
         path,
     }
 })


### PR DESCRIPTION
### Description
This pull request introduces support for cursor-based pagination in `nestjs-paginate`, addressing the feature request raised in [#1049](https://github.com/ppetzold/nestjs-paginate/issues/1049). Cursor pagination complements the existing offset-based approach (`LIMIT_AND_OFFSET` and `TAKE_AND_SKIP`) by providing a more efficient way to paginate large datasets, avoiding the performance issues associated with high offsets.

### Key Changes:
- **New Pagination Type**: Added `CURSOR` to the `PaginationType` enum, enabling cursor-based pagination alongside existing types.
- **Config Enhancement**: Introduced `cursorableColumns` in `PaginateConfig` to specify columns eligible for cursor pagination, ensuring flexibility and control over cursor keys.
- **Query Support**: Extended `PaginateQuery` to include `cursorColumn` and `cursorDirection` (`after` or `before`), allowing clients to define the cursor and traversal direction.
- **Response Structure**: Updated `Paginated` to include `meta.firstCursor` and `meta.lastCursor` for current page boundaries, and modified `links` to use `before` and `next` for cursor navigation (instead of `firstCursor`/`lastCursor` to align with intuitive navigation).
- **Implementation**: Modified the `paginate` function to handle cursor logic:
  - Validates `cursorableColumns`, `cursorColumn`, and `cursorDirection`.
  - Applies cursor-based filtering and sorting using TypeORM's query builder.
  - Generates navigation links with dynamic direction switching.
- **Tests**: Added comprehensive test cases in `paginate.spec.ts` to verify cursor pagination behavior, including edge cases like invalid `cursorColumn` or `cursorDirection`.

### Motivation
As noted in [#1049](https://github.com/ppetzold/nestjs-paginate/issues/1049), cursor pagination is crucial for efficiently handling large datasets, especially in scenarios where offset-based pagination becomes slow due to database index skipping. This implementation provides a robust and flexible solution while maintaining backward compatibility with existing features.

### Usage Example
```ts
const config: PaginateConfig<CatEntity> = {
    sortableColumns: ['id', 'name'],
    cursorableColumns: ['id'],
    paginationType: PaginationType.CURSOR,
    defaultLimit: 2,
};
const query: PaginateQuery = {
    path: '',
    cursorColumn: 'id',
    cursorDirection: 'after',
    cursor: '2',
};
const result = await paginate(query, catRepo, config);
```

### Notes:
- The cursor values are currently raw column values (e.g., `"2"` for `id`). Future enhancements could include cursor encryption for added security.
- The implementation avoids computing `totalItems` for cursor pagination to preserve performance benefits, aligning with common cursor-based patterns (e.g., Relay).

Closes #1049. Please review and let me know if any adjustments are needed!