### PR TITLE
JSONB filter values that are not dates are coerced into NaN

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -251,7 +251,7 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
             return new Date(value)
         }
 
-        if ((columnType === Number || isJsonb) && !Number.isNaN(value)) {
+        if ((columnType === Number || isJsonb) && !Number.isNaN(Number(value))) {
             return Number(value)
         }
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -21,7 +21,7 @@ import { PaginateQuery } from './decorator'
 import {
     checkIsArray,
     checkIsEmbedded,
-    checkIsJsonb,
+    checkIsJson,
     checkIsNestedRelation,
     checkIsRelation,
     extractVirtualProperty,
@@ -308,7 +308,7 @@ export function parseFilter<T>(
             const fixValue = fixColumnFilterValue(column, qb)
 
             const columnProperties = getPropertiesByColumnName(column)
-            const isJsonb = checkIsJsonb(qb, columnProperties.column)
+            const isJsonb = checkIsJson(qb, columnProperties.column)
 
             switch (token.operator) {
                 case FilterOperator.BTW:

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -205,11 +205,11 @@ export function checkIsJson(qb: SelectQueryBuilder<unknown>, propertyName: strin
         const parts = propertyName.split('.')
         const dbColumnName = parts[parts.length - 2]
 
-        const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(dbColumnName)?.type;
+        const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(dbColumnName)?.type
         return columnType === 'jsonb' || columnType === 'json'
     }
 
-    const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.type;
+    const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.type
     return columnType === 'jsonb' || columnType === 'json'
 }
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -196,7 +196,7 @@ export function checkIsArray(qb: SelectQueryBuilder<unknown>, propertyName: stri
     return !!qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.isArray
 }
 
-export function checkIsJsonb(qb: SelectQueryBuilder<unknown>, propertyName: string): boolean {
+export function checkIsJson(qb: SelectQueryBuilder<unknown>, propertyName: string): boolean {
     if (!qb || !propertyName) {
         return false
     }
@@ -205,10 +205,12 @@ export function checkIsJsonb(qb: SelectQueryBuilder<unknown>, propertyName: stri
         const parts = propertyName.split('.')
         const dbColumnName = parts[parts.length - 2]
 
-        return qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(dbColumnName)?.type === 'jsonb'
+        const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(dbColumnName)?.type;
+        return columnType === 'jsonb' || columnType === 'json'
     }
 
-    return qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.type === 'jsonb'
+    const columnType = qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.type;
+    return columnType === 'jsonb' || columnType === 'json'
 }
 
 // This function is used to fix the column alias when using relation, embedded or virtual properties


### PR DESCRIPTION
## Problem
The condition `!Number.isNaN(value)` was always true, causing all JSONB column queries to be coerced into `Number(value)`, which resulted in `NaN`.

## Solution
Updated the check to `!Number.isNaN(Number(value))` to ensure that the numeric conversion is properly validated before use.

Additionally, I also added the `json` column type as a valid JSON column type. Both `jsonb` and `json` seem to work just fine for JSON operations in TypeORM :)