### PR TITLE
feat: improve cursor pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .history
 .idea/
 .env
+test.sql

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-prettier": "^5.2.3",
         "fastify": "^5.2.1",
         "jest": "^29.7.0",
-        "mysql": "^2.18.1",
+        "mysql2": "^3.14.0",
         "pg": "^8.14.0",
         "prettier": "^3.0.3",
         "reflect-metadata": "^0.2.2",
@@ -2500,6 +2500,16 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2616,15 +2626,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -3352,6 +3353,16 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "optional": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4446,6 +4457,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4980,6 +5001,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -5844,6 +5872,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/long": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5855,6 +5890,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-error": {
@@ -6167,49 +6218,38 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+    "node_modules/mysql2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.0.tgz",
+      "integrity": "sha512-8eMhmG6gt/hRkU1G+8KlGOdQi2w+CgtNoD1ksXZq9gQfkfDsX4LHaBwTe1SY0Imx//t2iZA03DFnyYKPinxSRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 8.0"
       }
     },
-    "node_modules/mysql/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/mysql/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/mysql/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/mz": {
@@ -6221,6 +6261,29 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/napi-build-utils": {
@@ -7494,6 +7557,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
+      "dev": true
+    },
     "node_modules/serve-static": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
@@ -7771,10 +7840,11 @@
       }
     },
     "node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "fastify": "^5.2.1",
     "jest": "^29.7.0",
-    "mysql": "^2.18.1",
+    "mysql2": "^3.14.0",
     "pg": "^8.14.0",
     "prettier": "^3.0.3",
     "reflect-metadata": "^0.2.2",

--- a/src/__tests__/cat-hair.entity.ts
+++ b/src/__tests__/cat-hair.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { DateColumnNotNull } from './column-option'
 
 @Entity()
 export class CatHairEntity {
@@ -11,7 +12,7 @@ export class CatHairEntity {
     @Column({ type: 'text', array: true, default: '{}' })
     colors: string[]
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 
     @Column({ type: 'jsonb', nullable: true })

--- a/src/__tests__/cat-home-pillow.entity.ts
+++ b/src/__tests__/cat-home-pillow.entity.ts
@@ -1,6 +1,7 @@
 import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
-import { CatHomeEntity } from './cat-home.entity'
 import { CatHomePillowBrandEntity } from './cat-home-pillow-brand.entity'
+import { CatHomeEntity } from './cat-home.entity'
+import { DateColumnNotNull } from './column-option'
 
 @Entity()
 export class CatHomePillowEntity {
@@ -16,6 +17,6 @@ export class CatHomePillowEntity {
     @ManyToOne(() => CatHomePillowBrandEntity)
     brand: CatHomePillowBrandEntity
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 }

--- a/src/__tests__/cat-home.entity.ts
+++ b/src/__tests__/cat-home.entity.ts
@@ -38,7 +38,8 @@ export class CatHomeEntity {
     @VirtualColumn({
         query: (alias) => {
             const tck = process.env.DB === 'mariadb' ? '`' : '"'
-            return `SELECT CAST(COUNT(*) AS INT) FROM ${tck}cat${tck} WHERE ${tck}cat${tck}.${tck}homeId${tck} = ${alias}.id`
+            const intType = process.env.DB === 'mariadb' ? 'UNSIGNED' : 'INT'
+            return `SELECT CAST(COUNT(*) AS ${intType}) FROM ${tck}cat${tck} WHERE ${tck}cat${tck}.${tck}homeId${tck} = ${alias}.id`
         },
     })
     countCat: number

--- a/src/__tests__/cat-home.entity.ts
+++ b/src/__tests__/cat-home.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm'
 import { CatHomePillowEntity } from './cat-home-pillow.entity'
 import { CatEntity } from './cat.entity'
+import { DateColumnNotNull } from './column-option'
 
 @Entity()
 export class CatHomeEntity {
@@ -31,7 +32,7 @@ export class CatHomeEntity {
     @ManyToOne(() => CatHomePillowEntity, { nullable: true })
     naptimePillow: CatHomePillowEntity | null
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 
     @VirtualColumn({

--- a/src/__tests__/cat-toy.entity.ts
+++ b/src/__tests__/cat-toy.entity.ts
@@ -1,5 +1,6 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { CatEntity } from './cat.entity'
+import { DateColumnNotNull } from './column-option'
 import { SizeEmbed } from './size.embed'
 import { ToyShopEntity } from './toy-shop.entity'
 
@@ -22,6 +23,6 @@ export class CatToyEntity {
     @JoinColumn()
     cat: CatEntity
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 }

--- a/src/__tests__/cat.entity.ts
+++ b/src/__tests__/cat.entity.ts
@@ -64,12 +64,19 @@ export class CatEntity {
     @JoinTable()
     friends: CatEntity[]
 
+    @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
+    weightChange: number | null
+
     @AfterLoad()
     // Fix due to typeorm bug that doesn't set entity to null
     // when the reletated entity have only the virtual column property with a value different from null
     private afterLoad() {
         if (this.home && !this.home?.id) {
             this.home = null
+        }
+
+        if (this.weightChange) {
+            this.weightChange = Number(this.weightChange) // convert value returned as character to number
         }
     }
 }

--- a/src/__tests__/cat.entity.ts
+++ b/src/__tests__/cat.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm'
 import { CatHomeEntity } from './cat-home.entity'
 import { CatToyEntity } from './cat-toy.entity'
+import { DateColumnNotNull, DateColumnNullable } from './column-option'
 import { SizeEmbed } from './size.embed'
 
 export enum CutenessLevel {
@@ -38,7 +39,7 @@ export class CatEntity {
     @Column({ type: 'text' }) // We don't use enum type as it makes it easier when testing across different db drivers.
     cutenessLevel: CutenessLevel
 
-    @Column({ nullable: true })
+    @Column(DateColumnNullable)
     lastVetVisit: Date | null
 
     @Column(() => SizeEmbed)
@@ -53,10 +54,10 @@ export class CatEntity {
     @JoinColumn()
     home: CatHomeEntity
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 
-    @DeleteDateColumn({ nullable: true })
+    @DeleteDateColumn(DateColumnNullable)
     deletedAt?: string
 
     @ManyToMany(() => CatEntity)

--- a/src/__tests__/column-option.ts
+++ b/src/__tests__/column-option.ts
@@ -1,0 +1,26 @@
+import { ColumnOptions } from 'typeorm'
+
+const getDateColumnType = () => {
+    switch (process.env.DB) {
+        case 'postgres':
+        case 'cockroachdb':
+            return 'timestamptz'
+        case 'mysql':
+        case 'mariadb':
+            return 'timestamp'
+        case 'sqlite':
+            return 'datetime'
+        default:
+            return 'timestamp'
+    }
+}
+
+export const DateColumnNotNull: ColumnOptions = {
+    type: getDateColumnType(),
+    precision: 3,
+}
+
+export const DateColumnNullable: ColumnOptions = {
+    ...DateColumnNotNull,
+    nullable: true,
+}

--- a/src/__tests__/column-option.ts
+++ b/src/__tests__/column-option.ts
@@ -17,7 +17,6 @@ const getDateColumnType = () => {
 
 export const DateColumnNotNull: ColumnOptions = {
     type: getDateColumnType(),
-    precision: 3,
 }
 
 export const DateColumnNullable: ColumnOptions = {

--- a/src/__tests__/toy-shop-address.entity.ts
+++ b/src/__tests__/toy-shop-address.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { DateColumnNotNull } from './column-option'
 
 @Entity()
 export class ToyShopAddressEntity {
@@ -8,6 +9,6 @@ export class ToyShopAddressEntity {
     @Column()
     address: string
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 }

--- a/src/__tests__/toy-shop.entity.ts
+++ b/src/__tests__/toy-shop.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { DateColumnNotNull } from './column-option'
 import { ToyShopAddressEntity } from './toy-shop-address.entity'
 
 @Entity()
@@ -13,6 +14,6 @@ export class ToyShopEntity {
     @JoinColumn()
     address: ToyShopAddressEntity
 
-    @CreateDateColumn()
+    @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 }

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -109,8 +109,6 @@ describe('Decorator', () => {
             filter: undefined,
             select: undefined,
             cursor: undefined,
-            cursorColumn: undefined,
-            cursorDirection: undefined,
             path: 'http://localhost/items',
         })
     })
@@ -129,8 +127,6 @@ describe('Decorator', () => {
             filter: undefined,
             select: undefined,
             cursor: undefined,
-            cursorColumn: undefined,
-            cursorDirection: undefined,
             path: 'http://localhost/items',
         })
     })
@@ -145,8 +141,6 @@ describe('Decorator', () => {
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
             select: ['name', 'createdAt'],
             cursor: 'abc123',
-            cursorColumn: 'id',
-            cursorDirection: 'after',
         })
 
         const result: PaginateQuery = decoratorfactory(null, context)
@@ -167,8 +161,6 @@ describe('Decorator', () => {
                 createdAt: ['$gte:2020-01-01', '$lte:2020-12-31'],
             },
             cursor: 'abc123',
-            cursorColumn: 'id',
-            cursorDirection: 'after',
         })
     })
 
@@ -182,8 +174,6 @@ describe('Decorator', () => {
             'filter.createdAt': ['$gte:2020-01-01', '$lte:2020-12-31'],
             select: ['name', 'createdAt'],
             cursor: 'abc123',
-            cursorColumn: 'id',
-            cursorDirection: 'after',
         })
 
         const result: PaginateQuery = decoratorfactory(null, context)
@@ -204,8 +194,6 @@ describe('Decorator', () => {
             },
             select: ['name', 'createdAt'],
             cursor: 'abc123',
-            cursorColumn: 'id',
-            cursorDirection: 'after',
         })
     })
 })

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -20,8 +20,6 @@ export interface PaginateQuery {
     filter?: { [column: string]: string | string[] }
     select?: string[]
     cursor?: string
-    cursorColumn?: string
-    cursorDirection?: 'before' | 'after'
     path: string
 }
 
@@ -105,9 +103,6 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
         filter: Object.keys(filter).length ? filter : undefined,
         select,
         cursor: query.cursor ? query.cursor.toString() : undefined,
-        cursorColumn: query.cursorColumn ? query.cursorColumn.toString() : undefined,
-        cursorDirection:
-            query.cursorDirection === 'after' || query.cursorDirection === 'before' ? query.cursorDirection : undefined,
         path,
     }
 })

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -27,6 +27,7 @@ import {
     extractVirtualProperty,
     fixColumnAlias,
     getPropertiesByColumnName,
+    isDateColumnType,
     isISODate,
     JoinMethod,
 } from './helper'
@@ -247,7 +248,7 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
     const columnType = virtualProperty.type
 
     return (value: string) => {
-        if ((columnType === Date || isJsonb) && isISODate(value)) {
+        if ((isDateColumnType(columnType) || isJsonb) && isISODate(value)) {
             return new Date(value)
         }
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -300,3 +300,16 @@ export function mergeRelationSchema(...schemas: RelationSchema[]) {
     const noTrueOverride = (obj, source) => (source === true && obj !== undefined ? obj : undefined)
     return mergeWith({}, ...schemas, noTrueOverride)
 }
+
+export function getPaddedExpr(valueExpr: string, length: number, dbType: string): string {
+    const lengthStr = String(length)
+    if (dbType === 'postgres' || dbType === 'cockroachdb') {
+        return `LPAD((${valueExpr})::bigint::text, ${lengthStr}, '0')`
+    } else if (dbType === 'mysql' || dbType === 'mariadb') {
+        return `LPAD(${valueExpr}, ${lengthStr}, '0')`
+    } else {
+        // sqlite
+        const padding = '0'.repeat(length)
+        return `SUBSTR('${padding}' || CAST(${valueExpr} AS INTEGER), -${lengthStr}, ${lengthStr})`
+    }
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -313,3 +313,13 @@ export function getPaddedExpr(valueExpr: string, length: number, dbType: string)
         return `SUBSTR('${padding}' || CAST(${valueExpr} AS INTEGER), -${lengthStr}, ${lengthStr})`
     }
 }
+
+export function isDateColumnType(type: any): boolean {
+    const dateTypes = [
+        Date, // JavaScript Date class
+        'datetime',
+        'timestamp',
+        'timestamptz',
+    ]
+    return dateTypes.includes(type)
+}

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3448,7 +3448,7 @@ describe('paginate', () => {
                 }
 
                 const result = await paginate<CatEntity>(query, catRepo, config)
-                const expectedResult = [3, 4, 0, 1, 2].map((i) => {
+                const expectedResult = [3, 4, 5, 6, 0, 1, 2].map((i) => {
                     const ret = clone(cats[i])
                     if (i < 3) {
                         ret.home = clone(catHomes[i])

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -123,6 +123,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.HIGH,
                 lastVetVisit: isoStringToDate('2022-12-19T10:00:00.000Z'),
                 size: { height: 25, width: 10, length: 40 },
+                weightChange: -0.75,
             }),
             catRepo.create({
                 name: 'Garfield',
@@ -131,6 +132,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.MEDIUM,
                 lastVetVisit: isoStringToDate('2022-12-20T10:00:00.000Z'),
                 size: { height: 30, width: 15, length: 45 },
+                weightChange: 5.25,
             }),
             catRepo.create({
                 name: 'Shadow',
@@ -139,6 +141,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.HIGH,
                 lastVetVisit: isoStringToDate('2022-12-21T10:00:00.000Z'),
                 size: { height: 25, width: 10, length: 50 },
+                weightChange: -3,
             }),
             catRepo.create({
                 name: 'George',
@@ -147,6 +150,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.LOW,
                 lastVetVisit: null,
                 size: { height: 35, width: 12, length: 40 },
+                weightChange: 0,
             }),
             catRepo.create({
                 name: 'Leche',
@@ -155,6 +159,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.HIGH,
                 lastVetVisit: null,
                 size: { height: 10, width: 5, length: 15 },
+                weightChange: -1.25,
             }),
             catRepo.create({
                 name: 'Baby',
@@ -163,6 +168,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.HIGH,
                 lastVetVisit: null,
                 size: { height: 10, width: 5, length: 10 },
+                weightChange: 0.01,
             }),
             catRepo.create({
                 name: 'Adam',
@@ -171,6 +177,7 @@ describe('paginate', () => {
                 cutenessLevel: CutenessLevel.LOW,
                 lastVetVisit: isoStringToDate('2022-12-22T10:00:00.000Z'),
                 size: { height: 20, width: 15, length: 50 },
+                weightChange: 4.75,
             }),
         ])
 
@@ -3476,8 +3483,8 @@ describe('paginate', () => {
                 expect(result.data).toStrictEqual(cats.slice(0, 2))
                 expect(result.meta.itemsPerPage).toBe(2)
                 expect(result.meta.cursor).toBeUndefined()
-                expect(result.links.previous).toBe('?limit=2&sortBy=id:DESC&cursor=V000000000000001') // id=1, DESC (Milo) -> V + LPAD(1, 15, '0')
-                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V999999999999998`) // id=2, ASC (Garfield) -> V + 10^15 - 2
+                expect(result.links.previous).toBe('?limit=2&sortBy=id:DESC&cursor=V00000000001V0000') // id=1, DESC (Milo) -> V + LPAD(1, 11, '0') + V + LPAD(0, 4, '0')
+                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V99999999998X0000`) // id=2, ASC (Garfield) -> V + 10^11 - 2 + X + LPAD(0, 4, '0')
             })
 
             it('should paginate using cursor (id, ASC)', async () => {
@@ -3496,8 +3503,8 @@ describe('paginate', () => {
                 expect(result.data).toStrictEqual(cats.slice(0, 2))
                 expect(result.meta.itemsPerPage).toBe(2)
                 expect(result.meta.cursor).toBeUndefined()
-                expect(result.links.previous).toBe('?limit=2&sortBy=id:DESC&cursor=V000000000000001') // id=1, DESC (Milo) -> V + LPAD(1, 15, '0')
-                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V999999999999998`) // id=2, ASC (Garfield) -> V + 10^15 - 2
+                expect(result.links.previous).toBe('?limit=2&sortBy=id:DESC&cursor=V00000000001V0000') // id=1, DESC (Milo) -> V + LPAD(1, 11, '0') + V + LPAD(0, 4, '0')
+                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V99999999998X0000`) // id=2, ASC (Garfield) -> V + 10^11 - 2 + X + LPAD(0, 4, '0')
             })
 
             it('should paginate using cursor with specific cursor value (id, ASC)', async () => {
@@ -3508,16 +3515,16 @@ describe('paginate', () => {
                 }
                 const query: PaginateQuery = {
                     path: '',
-                    cursor: 'V999999999999998', // id=2, ASC (Garfield) -> V + 10^15 - 2
+                    cursor: 'V99999999998X0000', // id=2, ASC (Garfield)
                 }
 
                 const result = await paginate<CatEntity>(query, catRepo, config)
 
                 expect(result.data).toStrictEqual(cats.slice(2, 4))
                 expect(result.meta.itemsPerPage).toBe(2)
-                expect(result.meta.cursor).toBe('V999999999999998')
-                expect(result.links.previous).toBe(`?limit=2&sortBy=id:DESC&cursor=V000000000000003`) // id=3, DESC (Shadow) -> V + LPAD(3, 15, '0')
-                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V999999999999996`) // id=4, ASC (George) -> V + 10^15 - 4
+                expect(result.meta.cursor).toBe('V99999999998X0000')
+                expect(result.links.previous).toBe(`?limit=2&sortBy=id:DESC&cursor=V00000000003V0000`) // id=3, DESC (Shadow) -> V + LPAD(3, 11, '0') + V + LPAD(0, 4, '0')
+                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&cursor=V99999999996X0000`) // id=4, ASC (George) -> V + 10^11 - 4 + X + LPAD(0, 4, '0')
             })
 
             it('should handle end of data with cursor pagination (id, ASC)', async () => {
@@ -3528,14 +3535,14 @@ describe('paginate', () => {
                 }
                 const query: PaginateQuery = {
                     path: '',
-                    cursor: 'V999999999999993', // id=7, ASC (Baby) -> V + 10^15 - 7
+                    cursor: 'V99999999993X0000', // id=7, ASC (Baby) -> V + 10^11 - 7 + X + LPAD(0, 4, '0')
                 }
 
                 const result = await paginate<CatEntity>(query, catRepo, config)
 
                 expect(result.data).toStrictEqual([])
                 expect(result.meta.itemsPerPage).toBe(0)
-                expect(result.meta.cursor).toBe('V999999999999993')
+                expect(result.meta.cursor).toBe('V99999999993X0000')
                 expect(result.links.previous).toBeUndefined()
                 expect(result.links.next).toBeUndefined()
             })
@@ -3556,8 +3563,8 @@ describe('paginate', () => {
                 expect(result.data).toStrictEqual(cats.slice(5, 7).reverse())
                 expect(result.meta.itemsPerPage).toBe(2)
                 expect(result.meta.cursor).toBeUndefined()
-                expect(result.links.previous).toBe(`?limit=2&sortBy=id:ASC&cursor=V999999999999993`) // id=7, ASC (Adam) -> V + 10^15 - 7
-                expect(result.links.next).toBe('?limit=2&sortBy=id:DESC&cursor=V000000000000006') // id=6, DESC (Baby) -> V + LPAD(6, 15, '0')
+                expect(result.links.previous).toBe(`?limit=2&sortBy=id:ASC&cursor=V99999999993X0000`) // id=7, ASC (Adam) -> V + 10^11 - 7 + X + LPAD(0, 4, '0')
+                expect(result.links.next).toBe('?limit=2&sortBy=id:DESC&cursor=V00000000006V0000') // id=6, DESC (Baby) -> V + LPAD(6, 11, '0') + V + LPAD(0, 4, '0')
             })
 
             it('should paginate using cursor with specific cursor value (id, DESC)', async () => {
@@ -3568,7 +3575,7 @@ describe('paginate', () => {
                 }
                 const query: PaginateQuery = {
                     path: '',
-                    cursor: 'V000000000000004', // id=4, DESC (George) -> V + LPAD(4, 15, '0')
+                    cursor: 'V00000000004V0000', // id=4, DESC (George) -> V + LPAD(4, 11, '0') + V + LPAD(0, 4, '0')
                     sortBy: [['id', 'DESC']],
                 }
 
@@ -3576,9 +3583,9 @@ describe('paginate', () => {
 
                 expect(result.data).toStrictEqual(cats.slice(1, 3).reverse())
                 expect(result.meta.itemsPerPage).toBe(2)
-                expect(result.meta.cursor).toBe('V000000000000004')
-                expect(result.links.previous).toBe(`?limit=2&sortBy=id:ASC&cursor=V999999999999997`) // id=3, ASC (Shadow) -> V + 10^15 - 3
-                expect(result.links.next).toBe(`?limit=2&sortBy=id:DESC&cursor=V000000000000002`) // id=2, DESC (Garfield) -> V + LPAD(2, 15, '0')
+                expect(result.meta.cursor).toBe('V00000000004V0000')
+                expect(result.links.previous).toBe(`?limit=2&sortBy=id:ASC&cursor=V99999999997X0000`) // id=3, ASC (Shadow) -> V + 10^11 - 3 + X + LPAD(0, 4, '0')
+                expect(result.links.next).toBe(`?limit=2&sortBy=id:DESC&cursor=V00000000002V0000`) // id=2, DESC (Garfield) -> V + LPAD(2, 11, '0') + V + LPAD(0, 4, '0')
             })
 
             it('should handle end of data with cursor pagination (id, DESC)', async () => {
@@ -3589,7 +3596,7 @@ describe('paginate', () => {
                 }
                 const query: PaginateQuery = {
                     path: '',
-                    cursor: 'V000000000000001', // id=1, DESC (Milo) -> V + LPAD(1, 15, '0')
+                    cursor: 'V00000000001V0000', // id=1, DESC (Milo) -> V + LPAD(1, 11, '0') + V + LPAD(0, 4, '0')
                     sortBy: [['id', 'DESC']],
                 }
 
@@ -3597,7 +3604,7 @@ describe('paginate', () => {
 
                 expect(result.data).toStrictEqual([])
                 expect(result.meta.itemsPerPage).toBe(0)
-                expect(result.meta.cursor).toBe('V000000000000001')
+                expect(result.meta.cursor).toBe('V00000000001V0000')
                 expect(result.links.previous).toBeUndefined()
                 expect(result.links.next).toBeUndefined()
             })
@@ -3643,11 +3650,6 @@ describe('paginate', () => {
             })
         })
 
-        describe('sortBy: age', () => {
-            // 동일한 값을 가진 데이터의 경우 정렬이 보장되지 않는지 확인
-            it('test', async () => {})
-        })
-
         describe('sortBy: age, lastVetVisit', () => {
             it('should handle multiple cursor columns checking sorted data (age:ASC, lastVetVisit:ASC)', async () => {
                 const config: PaginateConfig<CatEntity> = {
@@ -3683,11 +3685,11 @@ describe('paginate', () => {
                     ['lastVetVisit', 'ASC'],
                 ])
                 expect(result.links.previous).toBe(
-                    '?limit=20&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=V000000000000000N000000000000000'
-                ) // age=0, DESC + lastVetVisit=null, DESC (Baby) -> V + LPAD(0, 15, '0') + N + LPAD(0, 15, '0')
+                    '?limit=20&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=N00000000000X0000A000000000000000'
+                ) // age=0, DESC + lastVetVisit=null, DESC (Baby) -> N + LPAD(0, 11, '0') + X + LPAD(0, 4, '0') + A + LPAD(0, 15, '0')
                 expect(result.links.next).toBe(
-                    '?limit=20&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=N000000000000000N000000000000000'
-                ) // age=null, ASC + lastVetVisit=null, ASC (Leche) -> N + LPAD(0, 15, '0') + N + LPAD(0, 15, '0')
+                    '?limit=20&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=A000000000000000A000000000000000'
+                ) // age=null, ASC + lastVetVisit=null, ASC (Leche) -> A + LPAD(0, 15, '0') + A + LPAD(0, 15, '0')
             })
 
             it('should handle multiple cursor columns checking combined cursor (age:ASC, lastVetVisit:ASC)', async () => {
@@ -3714,30 +3716,30 @@ describe('paginate', () => {
                     ['lastVetVisit', 'ASC'],
                 ])
                 expect(result.links.previous).toBe(
-                    '?limit=4&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=V000000000000000N000000000000000'
-                ) // age=0, DESC + lastVetVisit=null, DESC (Baby) -> V + LPAD(0, 15, '0') + N + LPAD(0, 15, '0')
+                    '?limit=4&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=N00000000000X0000A000000000000000'
+                ) // age=0, DESC + lastVetVisit=null, DESC (Baby) -> N + LPAD(0, 11, '0') + X + LPAD(0, 4, '0') + A + LPAD(0, 15, '0')
                 expect(result.links.next).toBe(
-                    '?limit=4&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=V999999999999996V998328296800000'
-                ) // age=4, ASC + lastVetVisit=2022-12-22T10:00:00.000Z, ASC (Adam) -> V + 10^15 - 4 + V + 10^15 - 1671703200000
+                    '?limit=4&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=V99999999996X0000V998328296800000'
+                ) // age=4, ASC + lastVetVisit=2022-12-22T10:00:00.000Z, ASC (Adam) -> V + 10^11 - 4 + X + LPAD(0, 4, '0') + V + 10^15 - 1671703200000
 
                 const result2 = await paginate<CatEntity>(
-                    { ...query, cursor: 'V999999999999996V998328296800000' },
+                    { ...query, cursor: 'V99999999996X0000V998328296800000' },
                     catRepo,
                     config
                 )
 
                 expect(result2.data).toStrictEqual([cats[1], cats[0], cats[4]]) // Garfield, Milo, Leche
-                expect(result2.meta.cursor).toBe('V999999999999996V998328296800000')
+                expect(result2.meta.cursor).toBe('V99999999996X0000V998328296800000')
                 expect(result2.meta.sortBy).toStrictEqual([
                     ['age', 'ASC'],
                     ['lastVetVisit', 'ASC'],
                 ])
                 expect(result2.links.previous).toBe(
-                    '?limit=4&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=V000000000000005V001671530400000'
-                ) // age=5, DESC + lastVetVisit=2022-12-20T10:00:00.000Z, DESC (Garfield) -> V + LPAD(5, 15, '0') + V + LPAD(1671530400000, 15, '0')
+                    '?limit=4&sortBy=age:DESC&sortBy=lastVetVisit:DESC&cursor=V00000000005V0000V001671530400000'
+                ) // age=5, DESC + lastVetVisit=2022-12-20T10:00:00.000Z, DESC (Garfield) -> V + LPAD(5, 11, '0') + V + LPAD(0, 4, '0') + V + LPAD(1671530400000, 15, '0')
                 expect(result2.links.next).toBe(
-                    `?limit=4&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=N000000000000000N000000000000000`
-                ) // age=null, ASC + lastVetVisit=null, ASC (Leche) -> N + LPAD(0, 15, '0') + N + LPAD(0, 15, '0')
+                    `?limit=4&sortBy=age:ASC&sortBy=lastVetVisit:ASC&cursor=A000000000000000A000000000000000`
+                ) // age=null, ASC + lastVetVisit=null, ASC (Leche) -> A + LPAD(0, 15, '0') + A + LPAD(0, 15, '0')
             })
 
             it('should handle multiple cursor columns with different directions (age:DESC, lastVetVisit:ASC)', async () => {
@@ -3774,11 +3776,11 @@ describe('paginate', () => {
                     ['lastVetVisit', 'ASC'],
                 ])
                 expect(result.links.previous).toBe(
-                    '?limit=20&sortBy=age:ASC&sortBy=lastVetVisit:DESC&cursor=V999999999999994V001671444000000'
-                ) // age=6, ASC + lastVetVisit=2022-12-19T10:00:00.000Z DESC (Milo) -> V + (10^15 - 6) + V + LPAD(1671444000000, 15, '0')
+                    '?limit=20&sortBy=age:ASC&sortBy=lastVetVisit:DESC&cursor=V99999999994X0000V001671444000000'
+                ) // age=6, ASC + lastVetVisit=2022-12-19T10:00:00.000Z DESC (Milo) -> V + (10^11 - 6) + X + LPAD(0, 4, '0') + V + LPAD(1671444000000, 15, '0')
                 expect(result.links.next).toBe(
-                    `?limit=20&sortBy=age:DESC&sortBy=lastVetVisit:ASC&cursor=N000000000000000N000000000000000`
-                ) // age=null, DESC + lastVetVisit=null, ASC (Leche) -> N + LPAD(0, 15, '0') + N + LPAD(0, 15, '0')
+                    `?limit=20&sortBy=age:DESC&sortBy=lastVetVisit:ASC&cursor=A000000000000000A000000000000000`
+                ) // age=null, DESC + lastVetVisit=null, ASC (Leche) -> A + LPAD(0, 15, '0') + A + LPAD(0, 15, '0')
             })
         })
 
@@ -3796,17 +3798,17 @@ describe('paginate', () => {
                 expect(result.data).toEqual(expect.arrayContaining(ageNotNullCats)) // If there are multiple data with the same age value, sorting is not guaranteed among them
                 expect(result.meta.itemsPerPage).toBe(6)
                 expect(result.meta.cursor).toBeUndefined()
-                expect(result.links.previous).toBe('?limit=6&sortBy=age:ASC&cursor=V999999999999994') // age=6 ASC (Milo) -> V + 10^15 - 6
-                expect(result.links.next).toBe('?limit=6&sortBy=age:DESC&cursor=V000000000000000') // age=0 DESC (Baby) -> V + LPAD(0, 15, '0')
+                expect(result.links.previous).toBe('?limit=6&sortBy=age:ASC&cursor=V99999999994X0000') // age=6 ASC (Milo) -> V + 10^11 - 6 + X + LPAD(0, 4, '0')
+                expect(result.links.next).toBe('?limit=6&sortBy=age:DESC&cursor=N00000000000X0000') // age=0 DESC (Baby) -> V + LPAD(0, 11, '0') + X + LPAD(0, 4, '0')
 
-                const result2 = await paginate({ path: '', cursor: 'V000000000000000', limit: 6 }, catRepo, config)
+                const result2 = await paginate({ path: '', cursor: 'N00000000000X0000', limit: 6 }, catRepo, config)
 
                 expect(result2.data).toStrictEqual([cats[4]]) // Leche
                 expect(result2.meta.itemsPerPage).toBe(1)
-                expect(result2.meta.cursor).toBe('V000000000000000')
-                expect(result2.links.previous).toBe('?limit=6&sortBy=age:ASC&cursor=N000000000000000') // age=null ASC (Leche) -> N + LPAD(0, 15, '0')
-                expect(result2.links.current).toBe('?limit=6&sortBy=age:DESC&cursor=V000000000000000')
-                expect(result2.links.next).toBe('?limit=6&sortBy=age:DESC&cursor=N000000000000000') // age=null DESC (Leche) -> N + LPAD(0, 15, '0')
+                expect(result2.meta.cursor).toBe('N00000000000X0000')
+                expect(result2.links.previous).toBe('?limit=6&sortBy=age:ASC&cursor=A000000000000000') // age=null ASC (Leche) -> A + LPAD(0, 15, '0')
+                expect(result2.links.current).toBe('?limit=6&sortBy=age:DESC&cursor=N00000000000X0000')
+                expect(result2.links.next).toBe('?limit=6&sortBy=age:DESC&cursor=A000000000000000') // age=null DESC (Leche) -> A + LPAD(0, 15, '0')
             })
 
             it('should handle 0 and null distinctly (ASC)', async () => {
@@ -3820,18 +3822,18 @@ describe('paginate', () => {
                 expect(result.data).toStrictEqual([cats[5]]) // Baby
                 expect(result.meta.itemsPerPage).toBe(1)
                 expect(result.meta.cursor).toBeUndefined()
-                expect(result.links.previous).toBe('?limit=1&sortBy=age:DESC&cursor=V000000000000000') // age=0 DESC (Baby) -> V + LPAD(0, 15, '0')
-                expect(result.links.next).toBe('?limit=1&sortBy=age:ASC&cursor=X000000000000000') // age=0 ASC (Baby) -> X + LPAD(0, 15, '0')
+                expect(result.links.previous).toBe('?limit=1&sortBy=age:DESC&cursor=N00000000000X0000') // age=0 DESC (Baby) -> N + LPAD(0, 11, '0') + X + LPAD(0, 4, '0')
+                expect(result.links.next).toBe('?limit=1&sortBy=age:ASC&cursor=X00000000000X0000') // age=0 ASC (Baby) -> X + LPAD(0, 11, '0') + X + LPAD(0, 4, '0')
 
-                const result2 = await paginate({ path: '', cursor: 'X000000000000000' }, catRepo, config)
+                const result2 = await paginate({ path: '', cursor: 'X00000000000X0000' }, catRepo, config)
 
                 const catsExceptBaby = cats.filter((cat) => cat.name !== 'Baby')
 
                 expect(result2.data).toEqual(expect.arrayContaining(catsExceptBaby)) // cats except Baby
-                expect(result2.meta.cursor).toBe('X000000000000000')
-                expect(result2.links.previous).toBe('?limit=20&sortBy=age:DESC&cursor=V000000000000003') // age=3 DESC (George) -> V + LPAD(3, 15, '0')
-                expect(result2.links.current).toBe('?limit=20&sortBy=age:ASC&cursor=X000000000000000')
-                expect(result2.links.next).toBe('?limit=20&sortBy=age:ASC&cursor=N000000000000000') // age=null ASC (Leche) -> N + LPAD(0, 15, '0')
+                expect(result2.meta.cursor).toBe('X00000000000X0000')
+                expect(result2.links.previous).toBe('?limit=20&sortBy=age:DESC&cursor=V00000000003V0000') // age=3 DESC (George) -> V + LPAD(3, 11, '0') + X + LPAD(0, 4, '0')
+                expect(result2.links.current).toBe('?limit=20&sortBy=age:ASC&cursor=X00000000000X0000')
+                expect(result2.links.next).toBe('?limit=20&sortBy=age:ASC&cursor=A000000000000000') // age=null ASC (Leche) -> A + LPAD(0, 15, '0')
             })
         })
 
@@ -3854,9 +3856,11 @@ describe('paginate', () => {
 
                 const whiteCats = cats.filter((cat) => cat.color === 'white')
                 expect(result.data).toStrictEqual(whiteCats.slice(0, 2))
-                expect(result.links.previous).toBe('?limit=2&sortBy=id:DESC&filter.color=white&cursor=V000000000000004')
+                expect(result.links.previous).toBe(
+                    '?limit=2&sortBy=id:DESC&filter.color=white&cursor=V00000000004V0000'
+                )
                 expect(result.links.current).toBe('?limit=2&sortBy=id:ASC&filter.color=white')
-                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&filter.color=white&cursor=V999999999999995`)
+                expect(result.links.next).toBe(`?limit=2&sortBy=id:ASC&filter.color=white&cursor=V99999999995X0000`)
             })
 
             it('should work with filter and cursor pagination (sortBy id + filter age)', async () => {
@@ -3879,10 +3883,153 @@ describe('paginate', () => {
                 const ageNotNullCats = cats.filter((cat) => cat.age !== null)
                 expect(result.data).toStrictEqual(ageNotNullCats.sort((a, b) => a.id - b.id))
                 expect(result.links.previous).toBe(
-                    '?limit=20&sortBy=id:DESC&filter.age=$not:$null&cursor=V000000000000001'
+                    '?limit=20&sortBy=id:DESC&filter.age=$not:$null&cursor=V00000000001V0000'
                 )
                 expect(result.links.current).toBe('?limit=20&sortBy=id:ASC&filter.age=$not:$null')
-                expect(result.links.next).toBe('?limit=20&sortBy=id:ASC&filter.age=$not:$null&cursor=V999999999999993')
+                expect(result.links.next).toBe('?limit=20&sortBy=id:ASC&filter.age=$not:$null&cursor=V99999999993X0000')
+            })
+        })
+
+        describe('handling data including decimal and negative numbers', () => {
+            it('should handle data including decimal and negative numbers (weightChange, ASC)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['weightChange'],
+                    paginationType: PaginationType.CURSOR,
+                    defaultSortBy: [['weightChange', 'ASC']],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+
+                const sortedCats = cats.sort((a, b) => a.weightChange - b.weightChange)
+                expect(result.data).toEqual(sortedCats)
+                expect(result.links.previous).toBe('?limit=20&sortBy=weightChange:DESC&cursor=M99999999997X0000') // weightChange=-3.00 DESC (Shadow) -> (M + 10^11 - 3) + (X + PAD(0, 4, '0'))
+                expect(result.links.next).toBe('?limit=20&sortBy=weightChange:ASC&cursor=V99999999995V7500') // weightChange=5.25 ASC (Garfield) -> (V + 10^11 - 5) + (V + 10^4 - 2500)
+            })
+
+            it('should handle data including decimal and negative numbers (weightChange, DESC)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['weightChange'],
+                    paginationType: PaginationType.CURSOR,
+                    defaultSortBy: [['weightChange', 'DESC']],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+
+                const sortedCats = cats.sort((a, b) => b.weightChange - a.weightChange)
+                expect(result.data).toEqual(sortedCats)
+                expect(result.links.previous).toBe('?limit=20&sortBy=weightChange:ASC&cursor=V99999999995V7500') // weightChange=5.25 ASC (Garfield) -> (V + 10^11 - 5) + (V + 10^4 - 2500)
+                expect(result.links.next).toBe('?limit=20&sortBy=weightChange:DESC&cursor=M99999999997X0000') // weightChange=-3.00 DESC (Shadow) -> (M + 10^11 - 3) + (X + LPAD(0, 4, '0'))
+            })
+
+            it('should put null values last', async () => {
+                const nullCat = await catRepo.save(
+                    catRepo.create({
+                        name: 'nullCat',
+                        color: 'black',
+                        age: null,
+                        weightChange: null,
+                        cutenessLevel: CutenessLevel.LOW,
+                        size: { height: 0, width: 0, length: 0 },
+                    })
+                )
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['weightChange'],
+                    paginationType: PaginationType.CURSOR,
+                    defaultSortBy: [['weightChange', 'ASC']],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                expect(result.data[result.data.length - 1]).toStrictEqual(nullCat)
+
+                await catRepo.remove(nullCat)
+            })
+
+            it('should handle multiple cursor columns checking sorted data (age:ASC, weightChange:ASC)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['age', 'weightChange'],
+                    paginationType: PaginationType.CURSOR,
+                    defaultSortBy: [
+                        ['age', 'ASC'],
+                        ['weightChange', 'ASC'],
+                    ],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                const ageNotNullCats = cats.filter((cat) => cat.age !== null)
+                const ageNullCats = cats.filter((cat) => cat.age === null)
+                const sortedAgeNotNullCats = ageNotNullCats.sort((a, b) => {
+                    if (a.age === b.age) {
+                        return a.weightChange - b.weightChange
+                    }
+                    return a.age - b.age
+                })
+                const sortedAgeNullCats = ageNullCats.sort((a, b) => {
+                    return a.weightChange - b.weightChange
+                })
+
+                expect(result.data).toEqual([...sortedAgeNotNullCats, ...sortedAgeNullCats])
+                expect(result.meta.cursor).toBeUndefined()
+                expect(result.meta.sortBy).toStrictEqual([
+                    ['age', 'ASC'],
+                    ['weightChange', 'ASC'],
+                ])
+                expect(result.links.previous).toBe(
+                    '?limit=20&sortBy=age:DESC&sortBy=weightChange:DESC&cursor=N00000000000X0000V00000000000V0100'
+                ) // age=0, DESC + weightChange=0.01 DESC (Baby) -> (V + LPAD(0, 11, '0')) + (X + LPAD(0, 4, '0')) + (V + LPAD(0, 11, '0')) + (V + LPAD(100, 4, '0'))
+                expect(result.links.next).toBe(
+                    '?limit=20&sortBy=age:ASC&sortBy=weightChange:ASC&cursor=A000000000000000Y00000000001V2500'
+                ) // age=null, ASC + weightChange=-1.25 ASC (Leche) -> (A + LPAD(0, 15, '0')) + (Y + LPAD(1, 11, '0')) + (V + LPAD(2500, 4, '0'))
+            })
+
+            it('should handle multiple cursor columns with different directions (age:DESC, weightChange:ASC)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['age', 'weightChange'],
+                    paginationType: PaginationType.CURSOR,
+                    defaultSortBy: [
+                        ['age', 'DESC'],
+                        ['weightChange', 'ASC'],
+                    ],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                const ageNotNullCats = cats.filter((cat) => cat.age !== null)
+                const ageNullCats = cats.filter((cat) => cat.age === null)
+                const sortedAgeNotNullCats = ageNotNullCats.sort((a, b) => {
+                    if (a.age === b.age) {
+                        return a.weightChange - b.weightChange
+                    }
+                    return b.age - a.age
+                })
+                const sortedAgeNullCats = ageNullCats.sort((a, b) => {
+                    return a.weightChange - b.weightChange
+                })
+                expect(result.data).toEqual([...sortedAgeNotNullCats, ...sortedAgeNullCats])
+                expect(result.meta.cursor).toBeUndefined()
+                expect(result.meta.sortBy).toStrictEqual([
+                    ['age', 'DESC'],
+                    ['weightChange', 'ASC'],
+                ])
+                expect(result.links.previous).toBe(
+                    '?limit=20&sortBy=age:ASC&sortBy=weightChange:DESC&cursor=V99999999994X0000N00000000000V2500'
+                ) // age=6, ASC + weightChange=-0.75 DESC (Milo) -> (V + 10^11 - 6) + (X + LPAD(0, 4, '0')) + (N + LPAD(0, 11, '0')) + (V + LPAD(10^4 - 7500), 4, '0'))
+                expect(result.links.next).toBe(
+                    '?limit=20&sortBy=age:DESC&sortBy=weightChange:ASC&cursor=A000000000000000Y00000000001V2500'
+                ) // age=null, DESC + weightChange=-1.25 ASC (Leche) -> (A + LPAD(0, 15, '0')) + (Y + LPAD(1, 11, '0')) + (V + LPAD(2500, 4, '0'))
             })
         })
     })

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -503,7 +503,7 @@ export async function paginate<T extends ObjectLiteral>(
                 queryBuilder.andWhere(`${cursorExpression} < :cursor`, { cursor: query.cursor })
             }
 
-            queryBuilder.orderBy('cursor', 'DESC')
+            queryBuilder.orderBy('`cursor`', 'DESC') // since cursor is a reserved word in mysql, wrap it in backticks to recognize it as an alias
         }
     }
 
@@ -681,6 +681,7 @@ export async function paginate<T extends ObjectLiteral>(
         ;[items, totalItems] = await queryBuilder.getManyAndCount()
     } else {
         items = await queryBuilder.getMany()
+        console.log(queryBuilder.getSql())
     }
 
     const sortByQuery = sortBy.map((order) => `&sortBy=${order.join(':')}`).join('')

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -503,7 +503,7 @@ export async function paginate<T extends ObjectLiteral>(
                 queryBuilder.andWhere(`${cursorExpression} < :cursor`, { cursor: query.cursor })
             }
 
-            queryBuilder.orderBy('`cursor`', 'DESC') // since cursor is a reserved word in mysql, wrap it in backticks to recognize it as an alias
+            isMySqlOrMariaDb ? queryBuilder.orderBy('`cursor`', 'DESC') : queryBuilder.orderBy('cursor', 'DESC') // since cursor is a reserved word in mysql, wrap it in backticks to recognize it as an alias
         }
     }
 
@@ -681,7 +681,6 @@ export async function paginate<T extends ObjectLiteral>(
         ;[items, totalItems] = await queryBuilder.getManyAndCount()
     } else {
         items = await queryBuilder.getMany()
-        console.log(queryBuilder.getSql())
     }
 
     const sortByQuery = sortBy.map((order) => `&sortBy=${order.join(':')}`).join('')

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -316,6 +316,7 @@ export async function paginate<T extends ObjectLiteral>(
     const getDateColumnExpression = (alias: string, dbType: string): string => {
         switch (dbType) {
             case 'mysql':
+            case 'mariadb':
                 return `UNIX_TIMESTAMP(${alias}) * 1000`
             case 'postgres':
                 return `EXTRACT(EPOCH FROM ${alias}) * 1000`

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -16,6 +16,7 @@ import {
     getPropertiesByColumnName,
     getQueryUrlComponents,
     includesAllPrimaryKeyColumns,
+    isDateColumnType,
     isEntityKey,
     isFindOperator,
     isISODate,
@@ -292,12 +293,7 @@ export async function paginate<T extends ObjectLiteral>(
                 const columnMeta = metadata.columns.find(
                     (col) => col.propertyName === getPropertiesByColumnName(column).propertyName
                 )
-                const isDateColumn =
-                    columnMeta &&
-                    (columnMeta.type === Date ||
-                        columnMeta.type === 'timestamp' ||
-                        columnMeta.type === 'timestamptz' ||
-                        columnMeta.type === 'datetime')
+                const isDateColumn = columnMeta && isDateColumnType(columnMeta.type)
 
                 if (value === null) {
                     return generateNullCursor()
@@ -480,12 +476,7 @@ export async function paginate<T extends ObjectLiteral>(
                 const columnProperties = getPropertiesByColumnName(column)
                 const alias = fixColumnAlias(columnProperties, queryBuilder.alias)
                 const columnMeta = metadata.columns.find((col) => col.propertyName === columnProperties.propertyName)
-                const isDateColumn =
-                    columnMeta &&
-                    (columnMeta.type === Date ||
-                        columnMeta.type === 'timestamp' ||
-                        columnMeta.type === 'timestamptz' ||
-                        columnMeta.type === 'datetime')
+                const isDateColumn = columnMeta && isDateColumnType(columnMeta.type)
                 const columnExpr = isDateColumn ? getDateColumnExpression(alias, dbType) : alias
 
                 return isDateColumn


### PR DESCRIPTION
### Description
This pull request enhances the cursor-based pagination support in `nestjs-paginate`, building upon the initial implementation from #1049-#1050, and introduces a new `weightChange` decimal column to the `CatEntity` along with supporting changes for date column management. The updated pagination implementation introduces a robust and flexible cursor generation mechanism, supporting multiple column types (e.g., dates, numbers, decimals) and improving database compatibility across MySQL, PostgreSQL, and SQLite.

### Key Changes:
1. **Enhanced Cursor Generation**:
   - Introduced a new cursor generation system that transforms column values into a composite string (e.g., `V001671444000000` for dates, `Y00000000001V2500` for numbers/decimals), supporting multiple sortable columns (e.g., `V99999999994X0000N00000000000V2500`).
   - Implemented database-specific expressions for cursor computation (e.g., `UNIX_TIMESTAMP` for MySQL, `EXTRACT(EPOCH)` for PostgreSQL).

2. **Config Updates**:
   - Removed `cursorableColumns` from `PaginateConfig` as the cursor now leverages the existing `sortableColumns`, simplifying configuration.
   - Retained `PaginationType.CURSOR` in the `PaginationType` enum, with improved integration into the existing pagination logic.

3. **Query and Response Adjustments**:
   - Updated `PaginateQuery` to rely solely on `cursor` without `cursorColumn` or `cursorDirection`, as direction is now inferred from `sortBy`.
   - Modified `Paginated` to remove `firstCursor` and `lastCursor` from `meta`, keeping only the current `cursor` for simplicity and consistency.
   - Adjusted navigation links (`previous`, `current`, `next`) to use the new cursor format, with dynamic sort order reversal for `previous`.

4. **Implementation Details**:
   - Added `generateCursor` helper to create composite cursor strings based on column values and sort direction, now supporting decimal types like `weightChange`.
   - Implemented database-specific cursor expressions in the query builder for efficient sorting and filtering.
   - Simplified cursor-based filtering by applying a single `WHERE` clause on the computed cursor expression.
   - Ensured compatibility with TypeORM’s query builder by dynamically adjusting SQL syntax for different database types.

5. **CatEntity Enhancements**:
   - Added a `weightChange` column to `CatEntity` with type `decimal` (precision: 5, scale: 2, nullable: true) to track weight changes in cats.
   - Updated the `@AfterLoad` hook to convert `weightChange` from a string (returned by some databases) to a number for consistency.
   - Added a new dummy cat object to test cases with the `weightChange` field populated.

6. **Date Column Management**:
   - Created a new `column-option.ts` file to centralize date column configuration:
     - `DateColumnNotNull`: Non-nullable timestamp with database-specific type (`timestamptz` for PostgreSQL/CockroachDB, `timestamp` for MySQL/MariaDB, `datetime` for SQLite).
     - `DateColumnNullable`: Nullable version of the above.

7. **Tests**:
   - Updated `paginate.spec.ts` with new test cases to validate cursor generation, multi-column sorting (including `weightChange`), and edge cases (e.g., null values, negative numbers, decimals, dates).
   - Added test cases for the new `weightChange` field in `CatEntity` with dummy data.

### Motivation
The previous cursor pagination implementation relied on raw column values, limiting flexibility and requiring additional configuration (`cursorableColumns`, `cursorColumn`, `cursorDirection`). This update eliminates those constraints by using a unified cursor string derived from `sortableColumns`, improving performance by avoiding total count calculations and enhancing usability with a more intuitive navigation model. The addition of `weightChange` to `CatEntity` and the `column-option.ts` utility further improves the library by supporting richer data models and ensuring consistent date column behavior across database types, aligning with modern cursor pagination patterns while maintaining compatibility with existing offset-based pagination.

### Usage Example
```typescript
const config: PaginateConfig<CatEntity> = {
    sortableColumns: ['age', 'weightChange'],
    paginationType: PaginationType.CURSOR,
    defaultLimit: 2,
};
const query: PaginateQuery = {
    path: '',
    sortBy: [['age', 'ASC'], ['weightChange', 'DESC']],
    cursor: 'V99999999994X0000N00000000000V2500', // Example cursor for age = 6, weightChange = -0.75
};
const result = await paginate(query, catRepo, config);
```

Closes #1049 (revisited). Please review and let me know if any adjustments are needed!