### PR TITLE
feat: add wildcard support for select parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * Description: TypeORM partial selection. Limit selection further by using `select` query param.
    * https://typeorm.io/select-query-builder#partial-selection
    * Note: if you do not contain the primary key in the select array, primary key will be added automatically.
+   * 
+   * Wildcard support:
+   * - Use '*' to select all columns from the main entity.
+   * - Use 'relation.*' to select all columns from a relation.
+   * - Use 'relation.subrelation.*' to select all columns from nested relations.
+   * 
+   * Examples:
+   * select: ['*'] - Selects all columns from main entity
+   * select: ['id', 'name', 'toys.*'] - Selects id, name from main entity and all columns from toys relation
+   * select: ['*', 'toys.*'] - Selects all columns from both main entity and toys relation
    */
   select: ['id', 'name', 'color'],
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -4748,16 +4748,18 @@ describe('paginate', () => {
                 page: 1,
                 limit: 10,
                 select: ['*', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
+                sortBy: [
+                    ['id', 'ASC'],
+                    ['toys.id', 'ASC'],
+                ],
                 path: '/cats',
             }
 
             const result = await paginate(query, catRepo, {
-                sortableColumns: ['id'],
+                sortableColumns: ['id', 'toys.id'],
                 select: ['*', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
                 relations: ['toys', 'toys.shop', 'toys.shop.address'],
             })
-
-            console.log(result.data[0])
 
             expect(result.data[0]).toHaveProperty('id')
             expect(result.data[0]).toHaveProperty('name')

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -4747,24 +4747,26 @@ describe('paginate', () => {
             const query: PaginateQuery = {
                 page: 1,
                 limit: 10,
-                select: ['id', 'name', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
+                select: ['*', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
                 path: '/cats',
             }
 
             const result = await paginate(query, catRepo, {
                 sortableColumns: ['id'],
-                select: ['id', 'name', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
+                select: ['*', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
                 relations: ['toys', 'toys.shop', 'toys.shop.address'],
             })
 
+            console.log(result.data[0])
+
             expect(result.data[0]).toHaveProperty('id')
             expect(result.data[0]).toHaveProperty('name')
-            expect(result.data[0].toys[0]).toHaveProperty('id')
-            expect(result.data[0].toys[0]).toHaveProperty('name')
-            expect(result.data[0].toys[0].shop).toHaveProperty('id')
-            expect(result.data[0].toys[0].shop).toHaveProperty('shopName')
-            expect(result.data[0].toys[0].shop.address).toHaveProperty('id')
-            expect(result.data[0].toys[0].shop.address).toHaveProperty('address')
+            expect(result.data[0].toys[1]).toHaveProperty('id')
+            expect(result.data[0].toys[1]).toHaveProperty('name')
+            expect(result.data[0].toys[1].shop).toHaveProperty('id')
+            expect(result.data[0].toys[1].shop).toHaveProperty('shopName')
+            expect(result.data[0].toys[1].shop.address).toHaveProperty('id')
+            expect(result.data[0].toys[1].shop.address).toHaveProperty('address')
         })
     })
 })

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -4635,4 +4635,136 @@ describe('paginate', () => {
             })
         })
     })
+
+    describe('Wildcard Select', () => {
+        it('should expand * wildcard to all main entity columns', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['*'],
+                path: '/cats',
+            }
+
+            const result = await paginate(query, catRepo, {
+                sortableColumns: ['id'],
+                select: ['*'],
+            })
+
+            expect(result.data[0]).toHaveProperty('id')
+            expect(result.data[0]).toHaveProperty('name')
+            expect(result.data[0]).toHaveProperty('color')
+            expect(result.data[0]).toHaveProperty('age')
+            expect(result.data[0]).toHaveProperty('cutenessLevel')
+            expect(result.data[0]).toHaveProperty('lastVetVisit')
+            expect(result.data[0]).toHaveProperty('createdAt')
+            expect(result.data[0]).toHaveProperty('deletedAt')
+            expect(result.data[0]).toHaveProperty('weightChange')
+            expect(result.data[0]).toHaveProperty('size')
+            expect(result.data[0]).toHaveProperty('size.height')
+            expect(result.data[0]).toHaveProperty('size.width')
+            expect(result.data[0]).toHaveProperty('size.length')
+        })
+
+        it('should expand relation.* wildcard to all relation columns', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['id', 'name', 'toys.*'],
+                path: '/cats',
+            }
+
+            const result = await paginate(query, catRepo, {
+                sortableColumns: ['id'],
+                select: ['id', 'name', 'toys.*'],
+                relations: ['toys'],
+            })
+
+            expect(result.data[0]).toHaveProperty('id')
+            expect(result.data[0]).toHaveProperty('name')
+            expect(result.data[0]).not.toHaveProperty('color')
+            expect(result.data[0]).not.toHaveProperty('age')
+            expect(result.data[0]).not.toHaveProperty('cutenessLevel')
+            expect(result.data[0]).not.toHaveProperty('lastVetVisit')
+            expect(result.data[0]).not.toHaveProperty('createdAt')
+            expect(result.data[0]).not.toHaveProperty('deletedAt')
+            expect(result.data[0]).not.toHaveProperty('weightChange')
+            expect(result.data[0].toys[0]).toHaveProperty('id')
+            expect(result.data[0].toys[0]).toHaveProperty('name')
+            expect(result.data[0].toys[0]).toHaveProperty('createdAt')
+            expect(result.data[0].toys[0]).toHaveProperty('size')
+            expect(result.data[0].toys[0]).toHaveProperty('size.height')
+            expect(result.data[0].toys[0]).toHaveProperty('size.width')
+            expect(result.data[0].toys[0]).toHaveProperty('size.length')
+        })
+
+        it('should handle both * and relation.* wildcards together', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['*', 'toys.*'],
+                path: '/cats',
+            }
+
+            const result = await paginate(query, catRepo, {
+                sortableColumns: ['id'],
+                select: ['*', 'toys.*'],
+                relations: ['toys'],
+            })
+
+            expect(result.data[0]).toHaveProperty('id')
+            expect(result.data[0]).toHaveProperty('name')
+            expect(result.data[0]).toHaveProperty('color')
+            expect(result.data[0]).toHaveProperty('age')
+            expect(result.data[0]).toHaveProperty('cutenessLevel')
+            expect(result.data[0]).toHaveProperty('lastVetVisit')
+            expect(result.data[0]).toHaveProperty('createdAt')
+            expect(result.data[0]).toHaveProperty('deletedAt')
+            expect(result.data[0]).toHaveProperty('weightChange')
+            expect(result.data[0].toys[0]).toHaveProperty('id')
+            expect(result.data[0].toys[0]).toHaveProperty('name')
+            expect(result.data[0].toys[0]).toHaveProperty('createdAt')
+        })
+
+        it('should handle non-existent relation wildcard gracefully', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['id', 'name', 'nonExistentRelation.*'],
+                path: '/cats',
+            }
+
+            const result = await paginate(query, catRepo, {
+                sortableColumns: ['id'],
+                select: ['id', 'name', 'nonExistentRelation.*'],
+            })
+
+            expect(result.data[0]).toHaveProperty('id')
+            expect(result.data[0]).toHaveProperty('name')
+            expect(result.data[0]).not.toHaveProperty('nonExistentRelation.*')
+        })
+
+        it('should handle nested relation wildcards correctly', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['id', 'name', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
+                path: '/cats',
+            }
+
+            const result = await paginate(query, catRepo, {
+                sortableColumns: ['id'],
+                select: ['id', 'name', 'toys.*', 'toys.shop.*', 'toys.shop.address.*'],
+                relations: ['toys', 'toys.shop', 'toys.shop.address'],
+            })
+
+            expect(result.data[0]).toHaveProperty('id')
+            expect(result.data[0]).toHaveProperty('name')
+            expect(result.data[0].toys[0]).toHaveProperty('id')
+            expect(result.data[0].toys[0]).toHaveProperty('name')
+            expect(result.data[0].toys[0].shop).toHaveProperty('id')
+            expect(result.data[0].toys[0].shop).toHaveProperty('shopName')
+            expect(result.data[0].toys[0].shop.address).toHaveProperty('id')
+            expect(result.data[0].toys[0].shop.address).toHaveProperty('address')
+        })
+    })
 })

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -734,7 +734,7 @@ export async function paginate<T extends ObjectLiteral>(
                                 .flat()
                                 .includes(col.propertyName)
                     )
-                    .map((col) => `${entityPath}.${col.propertyName}`)
+                    .map((col) => (entityPath ? `${entityPath}.${col.propertyName}` : col.propertyName))
             )
 
             // Add columns from embedded entities in the relation
@@ -749,7 +749,7 @@ export async function paginate<T extends ObjectLiteral>(
 
         for (const param of selectParams) {
             if (param === '*') {
-                expandedParams.push(..._expandWidcard(mainAlias.tablePath, mainMetadata))
+                expandedParams.push(..._expandWidcard('', mainMetadata))
             } else if (param.endsWith('.*')) {
                 // Handle relation entity wildcards (e.g. 'user.*', 'user.profile.*')
                 const parts = param.slice(0, -2).split('.')


### PR DESCRIPTION
related issue: resolves #950 

This PR introduces wildcard support in select parameters, allowing users to select all columns from main and relation entities using '*' notation. This enhancement provides more flexibility in column selection and simplifies queries when working with related entities.

# Key Changes
- Added support for '*' wildcard to select all columns from main entity
- Added support for 'relation.*' wildcard to select all columns from relation entities
- Implemented wildcard expansion for both config.select and query.select
- Added handling for embedded entity columns in wildcard expansion

# Technical Details:
1. Wildcard Expansion:
   - Main entity: '*' expands to all columns of the main entity (including embedded entity)
   - Relation entities: 'relation.*' expands to all columns of the specified relation
   - Nested relations: 'relation.subrelation.*' expands to all columns of nested relations

2. Implementation:
   - Added expandWildcardSelect function to handle wildcard expansion
   - Implemented recursive relation handling for nested relations of any depth
   - Used Set to remove duplicates while preserving column order
   - Added automatic inclusion of embedded entity columns when using wildcards

# Impact:
- Previous: Users had to explicitly list all desired columns
- After: Users can use wildcards to select all columns from entities
- Improved flexibility in column selection]

# Testing:
- Main entity wildcard (*):
  - Verifies all main entity columns are selected
  - Confirms embedded entity columns (size.height, size.width, size.length) are included
  - Validates all basic properties (id, name, color, age, etc.) are present

- Relation wildcard (relation.*):
  - Tests selection of specific columns with relation wildcard (id, name, toys.*)
  - Verifies only specified columns from main entity are included
  - Confirms all columns from relation entity are selected
  - Validates embedded entity columns in relations are included

- Combined wildcards:
  - Tests simultaneous use of * and relation.* wildcards
  - Verifies all columns from both main and relation entities are selected
  - Confirms no duplicate columns are included

- Error handling:
  - Ignores non-existent relation wildcards

- Nested relations:
  - Tests deep relation wildcards (toys.shop.*, toys.shop.address.*)
  - Validates proper selection of columns from nested relations
  - Confirms correct handling of multiple levels of relations