### PR TITLE
feat: added global configuration to simplify global routes configs an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ npm install nestjs-paginate
 
 ## Usage
 
+### Global configurations
+
+You can configure the global settings for all paginated routes by updating the default global configuration
+using below method. Ideally, you need to do it as soon as possible in your application main bootstrap method,
+as it affects all paginated routes, and swagger generation logic.
+
+```typescript
+import { updateGlobalConfig } from 'nestjs-paginate'
+
+updateGlobalConfig({
+  // this is default configuration
+  defaultOrigin: undefined,
+  defaultLimit: 20,
+  defaultMaxLimit: 100,
+});
+```
+
+
+
 ### Example
 
 The following code exposes a route that can be utilized like so:

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,0 +1,17 @@
+export interface NestjsPaginateGlobalConfig {
+    defaultOrigin: string | undefined
+    defaultLimit: number
+    defaultMaxLimit: number
+}
+
+const globalConfig: NestjsPaginateGlobalConfig = {
+    defaultOrigin: undefined,
+    defaultLimit: 20,
+    defaultMaxLimit: 100,
+}
+
+export const updateGlobalConfig = (newConfig: Partial<NestjsPaginateGlobalConfig>) => {
+    Object.assign(globalConfig, newConfig)
+}
+
+export default globalConfig

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -351,3 +351,11 @@ export function isDateColumnType(type: any): boolean {
 export function quoteVirtualColumn(columnName: string, isMySqlOrMariaDb: boolean): string {
     return isMySqlOrMariaDb ? `\`${columnName}\`` : `"${columnName}"`
 }
+
+export function isNil(v: unknown): boolean {
+    return v === null || v === undefined
+}
+
+export function isNotNil(v: unknown): boolean {
+    return !isNil(v)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './decorator'
 export * from './paginate'
 export * from './swagger'
+export * from './global-config'

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -28,6 +28,8 @@ import {
     isEntityKey,
     isFindOperator,
     isISODate,
+    isNil,
+    isNotNil,
     isRepository,
     JoinMethod,
     MappedColumns,
@@ -39,6 +41,7 @@ import {
     RelationSchemaInput,
     SortBy,
 } from './helper'
+import globalConfig from './global-config'
 
 const logger: Logger = new Logger('nestjs-paginate')
 
@@ -105,8 +108,6 @@ export interface PaginateConfig<T> {
 export enum PaginationLimit {
     NO_PAGINATION = -1,
     COUNTER_ONLY = 0,
-    DEFAULT_LIMIT = 20,
-    DEFAULT_MAX_LIMIT = 100,
 }
 
 function generateWhereStatement<T>(
@@ -208,8 +209,8 @@ export async function paginate<T extends ObjectLiteral>(
 
     const page = positiveNumberOrDefault(query.page, 1, 1)
 
-    const defaultLimit = config.defaultLimit || PaginationLimit.DEFAULT_LIMIT
-    const maxLimit = config.maxLimit || PaginationLimit.DEFAULT_MAX_LIMIT
+    const defaultLimit = config.defaultLimit || globalConfig.defaultLimit
+    const maxLimit = config.maxLimit || globalConfig.defaultMaxLimit
 
     const isPaginated = !(
         query.limit === PaginationLimit.COUNTER_ONLY ||
@@ -951,10 +952,10 @@ export async function paginate<T extends ObjectLiteral>(
         const { queryOrigin, queryPath } = getQueryUrlComponents(query.path)
         if (config.relativePath) {
             path = queryPath
-        } else if (config.origin) {
+        } else if (isNotNil(config.origin)) {
             path = config.origin + queryPath
         } else {
-            path = queryOrigin + queryPath
+            path = (isNil(globalConfig.defaultOrigin) ? queryOrigin : globalConfig.defaultOrigin) + queryPath
         }
     }
 

--- a/src/swagger/api-paginated-query.decorator.ts
+++ b/src/swagger/api-paginated-query.decorator.ts
@@ -1,7 +1,8 @@
 import { applyDecorators } from '@nestjs/common'
 import { ApiQuery } from '@nestjs/swagger'
 import { FilterComparator } from '../filter'
-import { FilterOperator, FilterSuffix, PaginateConfig, PaginationLimit } from '../paginate'
+import { FilterOperator, FilterSuffix, PaginateConfig } from '../paginate'
+import globalConfig from '../global-config'
 
 const DEFAULT_VALUE_KEY = 'Default Value'
 
@@ -45,8 +46,8 @@ function Limit(paginationConfig: PaginateConfig<any>) {
         name: 'limit',
         description: `Number of records per page.
       ${p('Example', '20')}
-      ${p(DEFAULT_VALUE_KEY, paginationConfig?.defaultLimit?.toString() || PaginationLimit.DEFAULT_LIMIT.toString())}
-      ${p('Max Value', paginationConfig.maxLimit?.toString() || PaginationLimit.DEFAULT_MAX_LIMIT.toString())}
+      ${p(DEFAULT_VALUE_KEY, paginationConfig?.defaultLimit?.toString() || globalConfig.defaultLimit.toString())}
+      ${p('Max Value', paginationConfig.maxLimit?.toString() || globalConfig.defaultMaxLimit.toString())}
 
       If provided value is greater than max value, max value will be applied.
       `,


### PR DESCRIPTION

It's a base global config to simplify an all routes configs, for now just with essential fields, but letter can be extended with any kind of config, like customisation for swagger 

and also it fixes this bug 

https://github.com/ppetzold/nestjs-paginate/issues/961 