### PR TITLE
`columnType` can be `"number"` for `VirtualColumn`s

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -252,7 +252,7 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
             return new Date(value)
         }
 
-        if ((columnType === Number || columnType === "number" || isJsonb) && !Number.isNaN(value)) {
+        if ((columnType === Number || columnType === 'number' || isJsonb) && !Number.isNaN(value)) {
             return Number(value)
         }
 


### PR DESCRIPTION
If the column is a virtual column then the `columnType` ended up being the string `"number"` rather than the `Number` constructor, and number values such as `"0"` were not converted.

I'm not sure if this should be unified upstream, so I added this quick fix. There's also the other case of dates right above it which might still suffer from the same bug.