### PR TITLE
feat: support JSONB filtering through relations with arbitrary nesting and $in operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,11 +589,74 @@ const config: PaginateConfig<CatEntity> = {
 
 `?filter.roles=$contains:moderator,admin` where column `roles` is an array and contains the values `moderator` and `admin`
 
-## Jsonb Filters
+## JSONB Filters
 
-You can filter on jsonb columns by using the dot notation. Json columns is limited to `$eq` operators only.
+You can filter on JSONB columns using dot notation to access nested fields.
 
-`?filter.metadata.enabled=$eq:true` where column `metadata` is jsonb and contains an object with the key `enabled`.
+### Supported operators
+
+| Operator | Description |
+|----------|-------------|
+| `$eq` | Exact match (`column @> '{"key":"value"}'`) |
+| `$in` | Match any of a comma-separated list of values |
+
+> **Note:** JSONB filtering is implemented using PostgreSQL's `@>` (containment) operator and is only supported by **PostgreSQL**.
+
+### Direct JSONB column
+
+```
+?filter.metadata.enabled=$eq:true
+```
+
+where `metadata` is a JSONB column and the filter matches rows whose `metadata` object contains `{ "enabled": true }`.
+
+### JSONB column through a relation
+
+Use the same dot notation to traverse relations before accessing the JSONB field:
+
+```
+?filter.settings.theme=$eq:dark
+```
+
+where `settings` is a relation whose JSONB column `theme` is filtered.
+
+```typescript
+const config: PaginateConfig<UserEntity> = {
+  relations: ['settings'],
+  filterableColumns: {
+    'settings.theme': [FilterOperator.EQ, FilterOperator.IN],
+  },
+}
+```
+
+### Deeply nested JSONB paths
+
+Paths inside the JSON value itself can be arbitrarily deep:
+
+```
+?filter.settings.ui.sidebar.color=$eq:blue
+```
+
+Regardless of nesting depth, the library walks TypeORM entity metadata to determine where the relation chain ends and the JSON key path begins, then builds the correct `@>` containment expression automatically.
+
+### `$in` operator on JSONB
+
+```
+?filter.metadata.status=$in:active,pending
+?filter.settings.theme=$in:dark,light
+```
+
+Each value is expanded into its own `@>` condition joined with `OR`:
+
+```sql
+(col @> '{"status":"active"}' OR col @> '{"status":"pending"}')
+```
+
+`$not:$in` is also supported and produces `NOT` conditions joined with `AND`:
+
+```
+?filter.metadata.status=$not:$in:banned,suspended
+```
 
 ## Multi Filters
 

--- a/src/__tests__/cat-home.entity.ts
+++ b/src/__tests__/cat-home.entity.ts
@@ -35,6 +35,9 @@ export class CatHomeEntity {
     @CreateDateColumn(DateColumnNotNull)
     createdAt: string
 
+    @Column({ type: process.env.DB === 'postgres' ? 'jsonb' : 'simple-json', nullable: true })
+    config: Record<string, any> | null
+
     @VirtualColumn({
         query: (alias) => {
             const tck = process.env.DB === 'mariadb' ? '`' : '"'

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -21,7 +21,6 @@ import { PaginateQuery } from './decorator'
 import {
     checkIsArray,
     checkIsEmbedded,
-    checkIsJsonb,
     checkIsNestedRelation,
     checkIsRelation,
     extractVirtualProperty,
@@ -30,6 +29,7 @@ import {
     isDateColumnType,
     isISODate,
     JoinMethod,
+    resolveJsonbPath,
 } from './helper'
 
 export enum FilterOperator {
@@ -252,7 +252,7 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
             return new Date(value)
         }
 
-        if ((columnType === Number || columnType === 'number' || isJsonb) && !Number.isNaN(value)) {
+        if ((columnType === Number || columnType === 'number' || isJsonb) && !isNaN(Number(value))) {
             return Number(value)
         }
 
@@ -309,7 +309,7 @@ export function parseFilter<T>(
             const fixValue = fixColumnFilterValue(column, qb)
 
             const columnProperties = getPropertiesByColumnName(column)
-            const isJsonb = checkIsJsonb(qb, columnProperties.column)
+            const jsonbResolution = resolveJsonbPath(qb, columnProperties.column)
 
             switch (token.operator) {
                 case FilterOperator.BTW:
@@ -331,34 +331,79 @@ export function parseFilter<T>(
                     params.findOperator = OperatorSymbolToFunction.get(token.operator)(fixValue(token.value))
             }
 
-            if (isJsonb) {
-                const parts = column.split('.')
-                const dbColumnName = parts[parts.length - 2]
-                const jsonColumnName = parts[parts.length - 1]
-
+            if (jsonbResolution.isJsonb) {
                 const jsonFixValue = fixColumnFilterValue(column, qb, true)
 
-                const jsonParams = {
-                    comparator: params.comparator,
-                    findOperator: JsonContains({
-                        [jsonColumnName]: jsonFixValue(token.value),
-                        //! Below seems to not be possible from my understanding, https://github.com/typeorm/typeorm/pull/9665
-                        //! This limits the functionaltiy to $eq only for json columns, which is a bit of a shame.
-                        //! If this is fixed or changed, we can use the commented line below instead.
-                        //[jsonColumnName]: params.findOperator,
-                    }),
+                // Use a stable filter key that preserves the relation path so that
+                // addWhereCondition can later resolve the correct JOIN alias.
+                // e.g. 'detail.referrer.source.platform' → filterKey = 'detail.referrer'
+                //      'metadata.length'                 → filterKey = 'metadata'
+                //      'underCoat.metadata.length'       → filterKey = 'underCoat.metadata'
+                const filterKey = [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
+
+                // Build a JsonContains containment object for a single leaf value.
+                // e.g. jsonPath=['source','platform'], value='web' → { source: { platform: 'web' } }
+                //      jsonPath=['length'],            value=5     → { length: 5 }
+                const buildContainment = (rawValue: string) => {
+                    const leafValue = jsonFixValue(rawValue)
+                    return jsonbResolution.jsonPath.reduceRight<Record<string, unknown>>(
+                        (acc, key) => ({ [key]: acc }),
+                        leafValue as unknown as Record<string, unknown>
+                    )
                 }
 
-                filter[dbColumnName] = [...(filter[column] || []), jsonParams]
+                if (token.operator === FilterOperator.IN) {
+                    // $in expands each comma-separated value to its own JsonContains condition.
+                    // Conditions after the first are OR'd together, producing:
+                    //   AND (col @> '{a}' OR col @> '{b}' OR col @> '{c}')
+                    // which is semantically equivalent to col->>'key' IN ('a', 'b', 'c').
+                    //
+                    //! JsonContains uses @> which only supports equality, not range operators.
+                    //! See: https://github.com/typeorm/typeorm/pull/9665
+                    token.value.split(',').forEach((val, i) => {
+                        filter[filterKey] = [
+                            ...(filter[filterKey] || []),
+                            {
+                                comparator: i === 0 ? params.comparator : FilterComparator.OR,
+                                findOperator: JsonContains(buildContainment(val.trim())),
+                            },
+                        ]
+                    })
+                } else {
+                    filter[filterKey] = [
+                        ...(filter[filterKey] || []),
+                        {
+                            comparator: params.comparator,
+                            findOperator: JsonContains(buildContainment(token.value)),
+                            //! JsonContains uses @> operator which only supports $eq semantics.
+                            //! See: https://github.com/typeorm/typeorm/pull/9665
+                        },
+                    ]
+                }
             } else {
                 filter[column] = [...(filter[column] || []), params]
             }
 
+            // suffix ($not) is applied on the filter key used above.
+            // For JSONB $in, $not must be applied to every expanded entry so that
+            // NOT (col @> '{a}') AND NOT (col @> '{b}') is produced (NOT IN semantics).
             if (token.suffix) {
-                const lastFilterElement = filter[column].length - 1
-                filter[column][lastFilterElement].findOperator = OperatorSymbolToFunction.get(token.suffix)(
-                    filter[column][lastFilterElement].findOperator
-                )
+                const filterKey = jsonbResolution.isJsonb
+                    ? [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
+                    : column
+                const isJsonbIn = jsonbResolution.isJsonb && token.operator === FilterOperator.IN
+                const applyFrom = isJsonbIn
+                    ? filter[filterKey].length - token.value.split(',').length
+                    : filter[filterKey].length - 1
+                for (let i = applyFrom; i < filter[filterKey].length; i++) {
+                    filter[filterKey][i].findOperator = OperatorSymbolToFunction.get(token.suffix)(
+                        filter[filterKey][i].findOperator
+                    )
+                    // $not:$in means NOT IN — all expanded values are AND'd with NOT
+                    if (isJsonbIn && i > applyFrom) {
+                        filter[filterKey][i].comparator = FilterComparator.AND
+                    }
+                }
             }
         }
     }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -225,14 +225,90 @@ export function checkIsJsonb(qb: SelectQueryBuilder<unknown>, propertyName: stri
         return false
     }
 
-    if (propertyName.includes('.')) {
-        const parts = propertyName.split('.')
-        const dbColumnName = parts[parts.length - 2]
+    const resolution = resolveJsonbPath(qb, propertyName)
+    return resolution.isJsonb
+}
 
-        return qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(dbColumnName)?.type === 'jsonb'
+/**
+ * Describes how a dot-separated filter path maps to a JSONB column.
+ *
+ * Given a path like `detail.referrer.source.platform`:
+ *   - relationPath: ['detail']           — segments that are TypeORM relations (require JOIN)
+ *   - jsonbColumn:  'referrer'           — the JSONB column on the final relation entity
+ *   - jsonPath:     ['source', 'platform'] — the key path inside the JSON value
+ */
+export interface JsonbPathResolution {
+    isJsonb: boolean
+    /** Relation segments leading up to the entity that owns the JSONB column */
+    relationPath: string[]
+    /** Name of the JSONB column on that entity */
+    jsonbColumn: string
+    /** Key path inside the JSON value (may be empty for a top-level JSONB filter) */
+    jsonPath: string[]
+}
+
+/**
+ * Walks the dot-separated `column` path through TypeORM entity metadata to determine
+ * whether the path terminates in a JSONB column and, if so, where the relation chain
+ * ends and the JSON key path begins.
+ *
+ * Algorithm:
+ *   For each segment, check whether the current entity metadata has a relation
+ *   with that name.  If yes, follow the relation and continue.  If no, check
+ *   whether it is a JSONB column on the current entity.  If yes, all remaining
+ *   segments are JSON key path.  Otherwise, the path is not JSONB.
+ */
+export function resolveJsonbPath(qb: SelectQueryBuilder<unknown>, column: string): JsonbPathResolution {
+    const notJsonb: JsonbPathResolution = { isJsonb: false, relationPath: [], jsonbColumn: '', jsonPath: [] }
+
+    if (!qb || !column) {
+        return notJsonb
     }
 
-    return qb?.expressionMap?.mainAlias?.metadata.findColumnWithPropertyName(propertyName)?.type === 'jsonb'
+    const parts = column.split('.')
+    // A plain column name without dots is not a JSONB path — callers use checkIsJsonb directly.
+    if (parts.length < 2) {
+        return notJsonb
+    }
+
+    let metadata = qb?.expressionMap?.mainAlias?.metadata
+    const relationPath: string[] = []
+
+    for (let i = 0; i < parts.length - 1; i++) {
+        const segment = parts[i]
+        const relation = metadata?.relations?.find((r) => r.propertyPath === segment)
+
+        if (relation) {
+            relationPath.push(segment)
+            metadata = relation.inverseEntityMetadata
+        } else {
+            // Not a relation — check whether it is a JSONB column
+            const isJsonbColumn = metadata?.findColumnWithPropertyName(segment)?.type === 'jsonb'
+            if (!isJsonbColumn) {
+                return notJsonb
+            }
+            return {
+                isJsonb: true,
+                relationPath,
+                jsonbColumn: segment,
+                jsonPath: parts.slice(i + 1),
+            }
+        }
+    }
+
+    // All segments except the last were relations; the last segment must be a JSONB column.
+    const lastSegment = parts[parts.length - 1]
+    const isJsonbColumn = metadata?.findColumnWithPropertyName(lastSegment)?.type === 'jsonb'
+    if (isJsonbColumn) {
+        return {
+            isJsonb: true,
+            relationPath,
+            jsonbColumn: lastSegment,
+            jsonPath: [],
+        }
+    }
+
+    return notJsonb
 }
 
 // This function is used to fix the column alias when using relation, embedded or virtual properties

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -219,9 +219,27 @@ describe('paginate', () => {
         pillowBrand = await catHomePillowBrandRepo.save({ name: 'Purrfection', quality: null })
         naptimePillow = await catHomePillowRepo.save({ color: 'black', brand: pillowBrand })
         catHomes = await catHomeRepo.save([
-            catHomeRepo.create({ name: 'Box', cat: cats[0], street: null, naptimePillow: null }),
-            catHomeRepo.create({ name: 'House', cat: cats[1], street: 'Mainstreet', naptimePillow: null }),
-            catHomeRepo.create({ name: 'Mansion', cat: cats[2], street: 'Boulevard Avenue', naptimePillow }),
+            catHomeRepo.create({
+                name: 'Box',
+                cat: cats[0],
+                street: null,
+                naptimePillow: null,
+                config: { theme: 'dark', fontSize: 14 },
+            }),
+            catHomeRepo.create({
+                name: 'House',
+                cat: cats[1],
+                street: 'Mainstreet',
+                naptimePillow: null,
+                config: { theme: 'light', fontSize: 12 },
+            }),
+            catHomeRepo.create({
+                name: 'Mansion',
+                cat: cats[2],
+                street: 'Boulevard Avenue',
+                naptimePillow,
+                config: { theme: 'dark', fontSize: 16, nested: { level: 2, tag: 'vip' } },
+            }),
         ])
         catHomePillows = await catHomePillowRepo.save([
             catHomePillowRepo.create({ color: 'red', home: catHomes[0] }),
@@ -3503,7 +3521,7 @@ describe('paginate', () => {
                 )
             })
 
-            it('should filter on a nested property through a relation', async () => {
+            it('should filter on a nested property through a relation (self-referencing entity)', async () => {
                 const config: PaginateConfig<CatHairEntity> = {
                     sortableColumns: ['id'],
                     filterableColumns: {
@@ -3514,19 +3532,149 @@ describe('paginate', () => {
                 const query: PaginateQuery = {
                     path: '',
                     filter: {
-                        'underCoat.metadata.length': '$eq:50',
+                        'underCoat.metadata.length': '$eq:5',
                     },
                 }
 
                 const result = await paginate<CatHairEntity>(query, catHairRepo, config)
 
                 expect(result.meta.filter).toStrictEqual({
-                    'underCoat.metadata.length': '$eq:50',
+                    'underCoat.metadata.length': '$eq:5',
                 })
                 expect(result.data).toStrictEqual([underCoats[0]])
                 expect(result.links.current).toBe(
-                    '?page=1&limit=20&sortBy=id:ASC&filter.underCoat.metadata.length=$eq:50'
+                    '?page=1&limit=20&sortBy=id:ASC&filter.underCoat.metadata.length=$eq:5'
                 )
+            })
+
+            it('should filter on a JSONB column through a different entity relation ($eq)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'home.config.theme': [FilterOperator.EQ],
+                    },
+                    relations: ['home'],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'home.config.theme': '$eq:dark',
+                    },
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'home.config.theme': '$eq:dark',
+                })
+                // cats[0]=Milo (Box, dark) and cats[2]=Shadow (Mansion, dark)
+                expect(result.data).toHaveLength(2)
+                expect(result.data.map((c) => c.name)).toEqual(expect.arrayContaining(['Milo', 'Shadow']))
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.config.theme=$eq:dark')
+            })
+
+            it('should filter on a 2-level deep JSONB path through a relation', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'home.config.nested.tag': [FilterOperator.EQ],
+                    },
+                    relations: ['home'],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'home.config.nested.tag': '$eq:vip',
+                    },
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'home.config.nested.tag': '$eq:vip',
+                })
+                // only cats[2]=Shadow (Mansion) has nested.tag = 'vip'
+                expect(result.data).toHaveLength(1)
+                expect(result.data[0].name).toBe('Shadow')
+                expect(result.links.current).toBe(
+                    '?page=1&limit=20&sortBy=id:ASC&filter.home.config.nested.tag=$eq:vip'
+                )
+            })
+
+            it('should filter on a direct JSONB column with a 2-level deep path', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadata.length': true,
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'metadata.length': '$eq:5',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadata.length': '$eq:5',
+                })
+                expect(result.data).toStrictEqual([catHairs[0]])
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadata.length=$eq:5')
+            })
+
+            it('should filter on a JSONB column through a relation using $in', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'home.config.theme': [FilterOperator.EQ, FilterOperator.IN],
+                    },
+                    relations: ['home'],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'home.config.theme': '$in:dark,light',
+                    },
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'home.config.theme': '$in:dark,light',
+                })
+                // Milo (dark), Garfield (light), Shadow (dark) all have homes
+                expect(result.data).toHaveLength(3)
+                expect(result.data.map((c) => c.name)).toEqual(expect.arrayContaining(['Milo', 'Garfield', 'Shadow']))
+                expect(result.links.current).toBe(
+                    '?page=1&limit=20&sortBy=id:ASC&filter.home.config.theme=$in:dark,light'
+                )
+            })
+
+            it('should filter on a direct JSONB column using $in', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadata.length': [FilterOperator.EQ, FilterOperator.IN],
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        // catHairs[0].length=5, catHairs[1].length=20
+                        'metadata.length': '$in:5,20',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadata.length': '$in:5,20',
+                })
+                expect(result.data).toHaveLength(2)
+                expect(result.data).toEqual(expect.arrayContaining([catHairs[0], catHairs[1]]))
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadata.length=$in:5,20')
             })
         })
     }


### PR DESCRIPTION
## Summary

- **Fix:** JSONB filter through a relation (e.g. `home.config.theme`) was silently applying the condition to the wrong table. TypeORM entity metadata is now walked segment-by-segment to locate exactly where the relation chain ends and the JSON key path begins, so the generated `@>` expression targets the correct JOIN alias.
- **Fix:** `fixColumnFilterValue` was calling `Number.isNaN(string)` which always returns `false` for string inputs, causing non-numeric JSONB values (e.g. `'dark'`) to be coerced to `NaN`. Changed to `!isNaN(Number(value))`.
- **Feat:** New `resolveJsonbPath` helper in `helper.ts` replaces the previous two-segment assumption with a full metadata traversal, enabling arbitrarily deep JSONB paths (e.g. `config.nested.level.tag`) across any number of relation hops.
- **Feat:** `$in` operator is now supported for JSONB columns. Each value is expanded into its own `JsonContains` condition OR'd together. `$not:$in` is also supported and produces NOT conditions AND'd together.

## Root cause (original bug)

When `parseFilter` encountered `home.config.theme`, it split the path as `dbColumnName = parts[length - 2] = 'config'` and stored the filter under `filter['config']`. This lost the `home` relation prefix, so `addWhereCondition` queried the main entity's `config` column (non-existent) instead of the joined `home` alias, triggering:

```
QueryFailedError: missing FROM-clause entry for table "cat_entity_home_rel_config_rel"
```

The underlying issue was that `checkIsJsonb` only searched the **main entity** metadata, so for a path like `home.config.theme` it looked for a column named `config` on `CatEntity`—not on the `CatHomeEntity` that owns it—and returned `false`. This caused the code to fall through to the standard relation-path branch, which attempted to JOIN a non-existent `config` relation table.

## Changes

| File | Description |
|------|-------------|
| `src/helper.ts` | Added `JsonbPathResolution` interface and `resolveJsonbPath` — walks TypeORM metadata through relation hops to precisely locate the JSONB column and JSON key path |
| `src/filter.ts` | Replaced `checkIsJsonb` call with `resolveJsonbPath`; fixed `Number.isNaN` string coercion bug; added `$in` expansion logic for JSONB |
| `src/__tests__/cat-home.entity.ts` | Added `config` JSONB column for cross-entity relation test coverage |
| `src/paginate.spec.ts` | Fixed self-referencing JSONB test (was accidentally passing due to the bug); added 4 new JSONB test cases |
| `README.md` | Rewrote JSONB Filters section: relation paths, arbitrary nesting, `$in` and `$not:$in` examples |

## Test plan

- [x] `$eq` on direct JSONB column (`metadata.length=$eq:5`)
- [x] `$eq` on JSONB through a different entity relation (`home.config.theme=$eq:dark`)
- [x] `$eq` on 2-level deep JSON path through relation (`home.config.nested.tag=$eq:vip`)
- [x] `$in` on direct JSONB column (`metadata.length=$in:5,20`)
- [x] `$in` on JSONB through relation (`home.config.theme=$in:dark,light`)
- [x] Self-referencing relation JSONB filter — corrected to verify the filter applies to the joined alias, not the main entity
- [x] Full regression: PostgreSQL 256 tests passed, SQLite 243 tests passed
