### PR TITLE
fix: use subquery expression for VirtualColumn ORDER BY to support PostgreSQL SELECT DISTINCT

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3711,84 +3711,84 @@ describe('paginate', () => {
     }
 
     describe('should return result based on virtual column', () => {
-            it('should return result sorted and filter by a virtual column in main entity', async () => {
-                const config: PaginateConfig<CatHomeEntity> = {
-                    sortableColumns: ['countCat'],
-                    relations: ['cat', 'naptimePillow.brand'],
-                    filterableColumns: {
-                        countCat: [FilterOperator.GT],
-                    },
-                }
-                const query: PaginateQuery = {
-                    path: '',
-                    filter: {
-                        countCat: '$gt:0',
-                    },
-                    sortBy: [['countCat', 'ASC']],
-                }
+        it('should return result sorted and filter by a virtual column in main entity', async () => {
+            const config: PaginateConfig<CatHomeEntity> = {
+                sortableColumns: ['countCat'],
+                relations: ['cat', 'naptimePillow.brand'],
+                filterableColumns: {
+                    countCat: [FilterOperator.GT],
+                },
+            }
+            const query: PaginateQuery = {
+                path: '',
+                filter: {
+                    countCat: '$gt:0',
+                },
+                sortBy: [['countCat', 'ASC']],
+            }
 
-                const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
+            const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
 
-                expect(result.data).toStrictEqual([catHomes[0], catHomes[1], catHomes[2]])
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=countCat:ASC&filter.countCat=$gt:0')
-            })
-
-            it('should return result based on virtual column filter', async () => {
-                const config: PaginateConfig<CatEntity> = {
-                    sortableColumns: ['id'],
-                    filterableColumns: {
-                        'home.countCat': [FilterOperator.GT],
-                    },
-                    relations: ['home', 'home.naptimePillow.brand'],
-                }
-                const query: PaginateQuery = {
-                    path: '',
-                    filter: {
-                        'home.countCat': '$gt:0',
-                    },
-                    sortBy: [['id', 'ASC']],
-                }
-
-                const result = await paginate<CatEntity>(query, catRepo, config)
-                const expectedResult = [0, 1, 2].map((i) => {
-                    const ret = Object.assign(clone(cats[i]), { home: Object.assign(clone(catHomes[i])) })
-                    delete ret.home.cat
-                    return ret
-                })
-
-                expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.countCat=$gt:0')
-            })
-
-            it('should return result sorted by a virtual column', async () => {
-                const config: PaginateConfig<CatEntity> = {
-                    sortableColumns: ['home.countCat'],
-                    relations: ['home', 'home.naptimePillow.brand'],
-                }
-                const query: PaginateQuery = {
-                    path: '',
-                    sortBy: [['home.countCat', 'ASC']],
-                }
-
-                const result = await paginate<CatEntity>(query, catRepo, config)
-                const expectedResult = [3, 4, 5, 6, 0, 1, 2].map((i) => {
-                    const ret = clone(cats[i])
-                    if (i < 3) {
-                        ret.home = clone(catHomes[i])
-                        ret.home.countCat = cats.filter((cat) => cat.id === ret.home.cat.id).length
-                        delete ret.home.cat
-                    } else {
-                        ret.home = null
-                    }
-                    return ret
-                })
-
-                expect(result.data).toStrictEqual(expectedResult)
-                expect(result.links.last).toBeUndefined()
-                expect(result.links.next).toBeUndefined()
-                expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
-            })
+            expect(result.data).toStrictEqual([catHomes[0], catHomes[1], catHomes[2]])
+            expect(result.links.current).toBe('?page=1&limit=20&sortBy=countCat:ASC&filter.countCat=$gt:0')
         })
+
+        it('should return result based on virtual column filter', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id'],
+                filterableColumns: {
+                    'home.countCat': [FilterOperator.GT],
+                },
+                relations: ['home', 'home.naptimePillow.brand'],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                filter: {
+                    'home.countCat': '$gt:0',
+                },
+                sortBy: [['id', 'ASC']],
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+            const expectedResult = [0, 1, 2].map((i) => {
+                const ret = Object.assign(clone(cats[i]), { home: Object.assign(clone(catHomes[i])) })
+                delete ret.home.cat
+                return ret
+            })
+
+            expect(result.data).toStrictEqual(expectedResult)
+            expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.home.countCat=$gt:0')
+        })
+
+        it('should return result sorted by a virtual column', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['home.countCat'],
+                relations: ['home', 'home.naptimePillow.brand'],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [['home.countCat', 'ASC']],
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+            const expectedResult = [3, 4, 5, 6, 0, 1, 2].map((i) => {
+                const ret = clone(cats[i])
+                if (i < 3) {
+                    ret.home = clone(catHomes[i])
+                    ret.home.countCat = cats.filter((cat) => cat.id === ret.home.cat.id).length
+                    delete ret.home.cat
+                } else {
+                    ret.home = null
+                }
+                return ret
+            })
+
+            expect(result.data).toStrictEqual(expectedResult)
+            expect(result.links.last).toBeUndefined()
+            expect(result.links.next).toBeUndefined()
+            expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
+        })
+    })
 
     describe('cursor pagination', () => {
         describe('sortBy: id', () => {

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3710,8 +3710,7 @@ describe('paginate', () => {
         })
     }
 
-    if (process.env.DB !== 'postgres') {
-        describe('should return result based on virtual column', () => {
+    describe('should return result based on virtual column', () => {
             it('should return result sorted and filter by a virtual column in main entity', async () => {
                 const config: PaginateConfig<CatHomeEntity> = {
                     sortableColumns: ['countCat'],
@@ -3790,7 +3789,6 @@ describe('paginate', () => {
                 expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
             })
         })
-    }
 
     describe('cursor pagination', () => {
         describe('sortBy: id', () => {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -691,7 +691,7 @@ export async function paginate<T extends ObjectLiteral>(
             const isEmbedded = checkIsEmbedded(queryBuilder, columnProperties.propertyPath)
             let alias = fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, isVirtualProperty, isEmbedded)
 
-            if (isVirtualProperty && virtualQuery) {
+            if (isVirtualProperty && virtualQuery && !isMySqlOrMariaDb) {
                 const subqueryExpr = fixColumnAlias(
                     columnProperties,
                     queryBuilder.alias,
@@ -700,7 +700,9 @@ export async function paginate<T extends ObjectLiteral>(
                     isEmbedded,
                     virtualQuery
                 )
-                const vcSortAlias = `_vc_sort_${columnProperties.propertyPath ? columnProperties.propertyPath + '_' : ''}${columnProperties.propertyName}`.toLowerCase()
+                const vcSortAlias = `_vc_sort_${
+                    columnProperties.propertyPath ? columnProperties.propertyPath + '_' : ''
+                }${columnProperties.propertyName}`.toLowerCase()
                 queryBuilder.addSelect(subqueryExpr, vcSortAlias)
                 alias = vcSortAlias
             } else if (isVirtualProperty) {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -686,12 +686,24 @@ export async function paginate<T extends ObjectLiteral>(
 
         for (const order of sortBy) {
             const columnProperties = getPropertiesByColumnName(order[0])
-            const { isVirtualProperty } = extractVirtualProperty(queryBuilder, columnProperties)
+            const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(queryBuilder, columnProperties)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
             const isEmbedded = checkIsEmbedded(queryBuilder, columnProperties.propertyPath)
             let alias = fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, isVirtualProperty, isEmbedded)
 
-            if (isVirtualProperty) {
+            if (isVirtualProperty && virtualQuery) {
+                const subqueryExpr = fixColumnAlias(
+                    columnProperties,
+                    queryBuilder.alias,
+                    isRelation,
+                    isVirtualProperty,
+                    isEmbedded,
+                    virtualQuery
+                )
+                const vcSortAlias = `_vc_sort_${columnProperties.propertyPath ? columnProperties.propertyPath + '_' : ''}${columnProperties.propertyName}`.toLowerCase()
+                queryBuilder.addSelect(subqueryExpr, vcSortAlias)
+                alias = vcSortAlias
+            } else if (isVirtualProperty) {
                 alias = quoteVirtualColumn(alias, isMySqlOrMariaDb)
             }
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -700,9 +700,7 @@ export async function paginate<T extends ObjectLiteral>(
                     isEmbedded,
                     virtualQuery
                 )
-                const vcSortAlias = `_vc_sort_${
-                    columnProperties.propertyPath ? columnProperties.propertyPath + '_' : ''
-                }${columnProperties.propertyName}`.toLowerCase()
+                const vcSortAlias = `${alias}_vc_sort`.toLowerCase()
                 queryBuilder.addSelect(subqueryExpr, vcSortAlias)
                 alias = vcSortAlias
             } else if (isVirtualProperty) {


### PR DESCRIPTION
  ## Summary

  Fixes `QueryFailedError: for SELECT DISTINCT, ORDER BY expressions must appear in select list` when sorting by a VirtualColumn on PostgreSQL with relations configured.

  ## Problem

  When relations are present, TypeORM wraps pagination queries in a `SELECT DISTINCT` subquery. The VirtualColumn's ORDER BY alias (e.g. `"__root_home_rel_countCat"`) is present in the inner SELECT but not in the outer DISTINCT SELECT list. PostgreSQL strictly enforces
  that ORDER BY expressions must appear in the SELECT list when using DISTINCT, causing the query to fail.

  MySQL/MariaDB/SQLite do not enforce this constraint, so the bug only manifests on PostgreSQL. The existing tests explicitly excluded PostgreSQL with an `if (process.env.DB !== 'postgres')` guard.

  **Conditions to reproduce:**
  - PostgreSQL
  - `PaginateConfig` with `relations`
  - `sortBy` targeting a VirtualColumn (either on the main entity or a relation)

  ## Root Cause

  In the ORDER BY loop of `paginate.ts`, the `query` function from `extractVirtualProperty` was not being utilized. Every other call site in the codebase (cursor pagination, search, filter) correctly extracts and passes `query` — this was the only one missing it.

  TypeORM's `createOrderByCombinedWithSelectExpression` determines which columns to include in the outer DISTINCT SELECT by checking `expressionMap.selects`. VirtualColumns are added to the SELECT via entity metadata, not through `expressionMap.selects`, so they are
  excluded from the outer DISTINCT SELECT.

  ## Solution

  On non-MySQL/MariaDB databases (PostgreSQL, SQLite), when a VirtualColumn has a `query` function, register its subquery expression in `queryBuilder.addSelect()` with a unique alias derived from the existing alias (following the same pattern as `nullSort`'s
  `${alias}IsNull`). This ensures:

  1. The column is registered in `expressionMap.selects`, so TypeORM's DISTINCT wrapper includes it in the outer SELECT
  2. ORDER BY references this unique alias, satisfying PostgreSQL's DISTINCT constraint
  3. A distinct alias name (suffixed with `_vc_sort`) avoids ambiguous column errors with TypeORM's own VirtualColumn alias
  4. The alias is lowercased to match PostgreSQL's unquoted identifier folding behavior

  MySQL/MariaDB retains the existing behavior as they do not have this constraint.

  ```typescript
  // Before
  const { isVirtualProperty } = extractVirtualProperty(queryBuilder, columnProperties)
  let alias = fixColumnAlias(...)
  if (isVirtualProperty) {
      alias = quoteVirtualColumn(alias, isMySqlOrMariaDb)
  }

  // After
  const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(queryBuilder, columnProperties)
  let alias = fixColumnAlias(...)
  if (isVirtualProperty && virtualQuery && !isMySqlOrMariaDb) {
      const subqueryExpr = fixColumnAlias(..., virtualQuery)
      const vcSortAlias = `${alias}_vc_sort`.toLowerCase()
      queryBuilder.addSelect(subqueryExpr, vcSortAlias)
      alias = vcSortAlias
  } else if (isVirtualProperty) {
      alias = quoteVirtualColumn(alias, isMySqlOrMariaDb)
  }

  Changes

  - src/paginate.ts — Register VirtualColumn subquery expression with a unique alias via addSelect in the ORDER BY loop (non-MySQL/MariaDB only)
  - src/paginate.spec.ts — Remove if (process.env.DB !== 'postgres') guard from VirtualColumn tests