### PR TITLE
Fix filter coercion and ISO date validation

### DIFF
--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -1,0 +1,40 @@
+import { parseFilter } from './filter'
+import { isISODate } from './helper'
+
+function createQueryBuilderMock(columns: Array<{ propertyName: string; type: unknown }>): any {
+    return {
+        expressionMap: {
+            mainAlias: {
+                metadata: {
+                    columns,
+                    relations: [],
+                    findColumnWithPropertyPath: () => undefined,
+                    findColumnWithPropertyName: (propertyName: string) =>
+                        columns.find((column) => column.propertyName === propertyName),
+                },
+            },
+        },
+    }
+}
+
+describe('parseFilter', () => {
+    it('casts $in values to numbers for numeric columns', () => {
+        const qb = createQueryBuilderMock([{ propertyName: 'age', type: Number }])
+
+        const result = parseFilter(
+            { path: '', filter: { age: '$in:1, 2,3' } },
+            {
+                age: true,
+            },
+            qb
+        )
+
+        expect((result.age[0].findOperator as any).value).toEqual([1, 2, 3])
+    })
+})
+
+describe('isISODate', () => {
+    it('returns false when a valid ISO date is only part of the input', () => {
+        expect(isISODate('prefix 2024-01-01T12:30:45Z suffix')).toBe(false)
+    })
+})

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -319,7 +319,9 @@ export function parseFilter<T>(
                     break
                 case FilterOperator.IN:
                 case FilterOperator.CONTAINS:
-                    params.findOperator = OperatorSymbolToFunction.get(token.operator)(token.value.split(','))
+                    params.findOperator = OperatorSymbolToFunction.get(token.operator)(
+                        token.value.split(',').map((v) => fixValue(v.trim()))
+                    )
                     break
                 case FilterOperator.ILIKE:
                     params.findOperator = OperatorSymbolToFunction.get(token.operator)(`%${token.value}%`)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -363,7 +363,7 @@ export function getQueryUrlComponents(path: string): { queryOrigin: string; quer
 }
 
 const isoDateRegExp = new RegExp(
-    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/
+    /^((\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)))$/
 )
 
 export function isISODate(str: string): boolean {


### PR DESCRIPTION
Motivation

    $in and $contains parsing produced untrimmed string arrays and skipped column-aware coercion, causing numeric/date-capable columns to receive wrong types.
    isISODate() produced false positives when an ISO timestamp appeared as a substring inside a larger string because the regex was not anchored to the full input.

Description

    Trim and coerce each comma-separated value for $in and $contains by mapping the split values through the existing fixValue logic in src/filter.ts.
    Anchor the ISO date regular expression in src/helper.ts with ^...$ so isISODate() requires the entire input to match an ISO timestamp.
    Add src/filter.spec.ts with focused unit tests that exercise $in numeric coercion and partial-string rejection for isISODate().

Testing

    Executed npm test -- --runInBand src/filter.spec.ts which passed (2 tests passed).
    Executed the full suite with npm test -- --runInBand and observed unrelated integration tests fail due to missing DB configuration in src/paginate.spec.ts (environment-dependent failure), so the focused unit tests were used for regression verification.
