### PR TITLE
Extend JSONB Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,18 +589,27 @@ const config: PaginateConfig<CatEntity> = {
 
 `?filter.roles=$contains:moderator,admin` where column `roles` is an array and contains the values `moderator` and `admin`
 
-## JSONB Filters
+## JSONB Support
 
-You can filter on JSONB columns using dot notation to access nested fields.
+You can sort, search, and filter on JSONB columns using dot notation to access nested fields.
 
-### Supported operators
+### Database support matrix
+
+| Feature | PostgreSQL / CockroachDB | MySQL / MariaDB | SQLite |
+|---------|---|---|---|
+| **Sorting** (`sortableColumns`) | Yes (`#>>`) | Yes (`JSON_UNQUOTE(JSON_EXTRACT(...))`) | Yes (`json_extract`) |
+| **Searching** (`searchableColumns`) | Yes | Yes | Yes |
+| **Filtering** (`$eq`, `$in`, `$contains`) | Yes (`@>` containment) | No | No |
+
+> **Note:** Sorting and searching on JSONB paths is supported across all database engines — the library automatically uses the correct JSON extraction function for your DB. Filtering via `$eq`, `$in`, and `$contains` uses PostgreSQL's `@>` containment operator (via TypeORM's `JsonContains`) and is only supported on **PostgreSQL** and **CockroachDB**.
+
+### Filtering operators (PostgreSQL / CockroachDB only)
 
 | Operator | Description |
 |----------|-------------|
-| `$eq` | Exact match (`column @> '{"key":"value"}'`) |
-| `$in` | Match any of a comma-separated list of values |
-
-> **Note:** JSONB filtering is implemented using PostgreSQL's `@>` (containment) operator and is only supported by **PostgreSQL**.
+| `$eq`       | Exact match via containment (`col @> '{"key":"value"}'`) |
+| `$in`       | Match any of a comma-separated list of values |
+| `$contains` | Match if a JSON array contains the value |
 
 ### Direct JSONB column
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -171,7 +171,7 @@ export function addWhereCondition<T>(qb: SelectQueryBuilder<T>, column: string, 
     const isEmbedded = checkIsEmbedded(qb, columnProperties.propertyPath)
     const isArray = checkIsArray(qb, columnProperties.propertyName)
 
-    const alias = fixColumnAlias(columnProperties, qb.alias, isRelation, isVirtualProperty, isEmbedded, virtualQuery)
+    const alias = fixColumnAlias(columnProperties, qb.alias, isRelation, isVirtualProperty, isEmbedded, virtualQuery, qb)
     filter[column].forEach((columnFilter: Filter, index: number) => {
         const columnNamePerIteration = `${columnProperties.column}${index}`
         const condition = generatePredicateCondition(
@@ -334,53 +334,52 @@ export function parseFilter<T>(
             }
 
             if (jsonbResolution.isJsonb) {
-                const jsonFixValue = fixColumnFilterValue(column, qb, true)
+                const supportJsonContains = [FilterOperator.EQ, FilterOperator.IN, FilterOperator.CONTAINS].includes(
+                    token.operator
+                )
 
-                // Use a stable filter key that preserves the relation path so that
-                // addWhereCondition can later resolve the correct JOIN alias.
-                // e.g. 'detail.referrer.source.platform' → filterKey = 'detail.referrer'
-                //      'metadata.length'                 → filterKey = 'metadata'
-                //      'underCoat.metadata.length'       → filterKey = 'underCoat.metadata'
-                const filterKey = [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
+                if (supportJsonContains) {
+                    const jsonFixValue = fixColumnFilterValue(column, qb, true)
 
-                // Build a JsonContains containment object for a single leaf value.
-                // e.g. jsonPath=['source','platform'], value='web' → { source: { platform: 'web' } }
-                //      jsonPath=['length'],            value=5     → { length: 5 }
-                const buildContainment = (rawValue: string) => {
-                    const leafValue = jsonFixValue(rawValue)
-                    return jsonbResolution.jsonPath.reduceRight<Record<string, unknown>>(
-                        (acc, key) => ({ [key]: acc }),
-                        leafValue as unknown as Record<string, unknown>
-                    )
-                }
+                    // Use a stable filter key that preserves the relation path so that
+                    // addWhereCondition can later resolve the correct JOIN alias.
+                    // e.g. 'detail.referrer.source.platform' → filterKey = 'detail.referrer'
+                    //      'metadata.length'                 → filterKey = 'metadata'
+                    //      'underCoat.metadata.length'       → filterKey = 'underCoat.metadata'
+                    const filterKey = [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
 
-                if (token.operator === FilterOperator.IN) {
-                    // $in expands each comma-separated value to its own JsonContains condition.
-                    // Conditions after the first are OR'd together, producing:
-                    //   AND (col @> '{a}' OR col @> '{b}' OR col @> '{c}')
-                    // which is semantically equivalent to col->>'key' IN ('a', 'b', 'c').
-                    //
-                    //! JsonContains uses @> which only supports equality, not range operators.
-                    //! See: https://github.com/typeorm/typeorm/pull/9665
-                    token.value.split(',').forEach((val, i) => {
+                    // Build a JsonContains containment object for a single leaf value.
+                    // e.g. jsonPath=['source','platform'], value='web' → { source: { platform: 'web' } }
+                    //      jsonPath=['length'],            value=5     → { length: 5 }
+                    const buildContainment = (rawValue: string) => {
+                        const leafValue = jsonFixValue(rawValue)
+                        return jsonbResolution.jsonPath.reduceRight<Record<string, unknown>>(
+                            (acc, key) => ({ [key]: acc }),
+                            leafValue as unknown as Record<string, unknown>
+                        )
+                    }
+
+                    if (token.operator === FilterOperator.IN) {
+                        token.value.split(',').forEach((val, i) => {
+                            filter[filterKey] = [
+                                ...(filter[filterKey] || []),
+                                {
+                                    comparator: i === 0 ? params.comparator : FilterComparator.OR,
+                                    findOperator: JsonContains(buildContainment(val.trim())),
+                                },
+                            ]
+                        })
+                    } else {
                         filter[filterKey] = [
                             ...(filter[filterKey] || []),
                             {
-                                comparator: i === 0 ? params.comparator : FilterComparator.OR,
-                                findOperator: JsonContains(buildContainment(val.trim())),
+                                comparator: params.comparator,
+                                findOperator: JsonContains(buildContainment(token.value)),
                             },
                         ]
-                    })
+                    }
                 } else {
-                    filter[filterKey] = [
-                        ...(filter[filterKey] || []),
-                        {
-                            comparator: params.comparator,
-                            findOperator: JsonContains(buildContainment(token.value)),
-                            //! JsonContains uses @> operator which only supports $eq semantics.
-                            //! See: https://github.com/typeorm/typeorm/pull/9665
-                        },
-                    ]
+                    filter[column] = [...(filter[column] || []), params]
                 }
             } else {
                 filter[column] = [...(filter[column] || []), params]
@@ -390,10 +389,14 @@ export function parseFilter<T>(
             // For JSONB $in, $not must be applied to every expanded entry so that
             // NOT (col @> '{a}') AND NOT (col @> '{b}') is produced (NOT IN semantics).
             if (token.suffix) {
-                const filterKey = jsonbResolution.isJsonb
+                const isJsonbAndSupportsJsonContains =
+                    jsonbResolution.isJsonb &&
+                    [FilterOperator.EQ, FilterOperator.IN, FilterOperator.CONTAINS].includes(token.operator)
+
+                const filterKey = isJsonbAndSupportsJsonContains
                     ? [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
                     : column
-                const isJsonbIn = jsonbResolution.isJsonb && token.operator === FilterOperator.IN
+                const isJsonbIn = isJsonbAndSupportsJsonContains && token.operator === FilterOperator.IN
                 const applyFrom = isJsonbIn
                     ? filter[filterKey].length - token.value.split(',').length
                     : filter[filterKey].length - 1

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -171,7 +171,15 @@ export function addWhereCondition<T>(qb: SelectQueryBuilder<T>, column: string, 
     const isEmbedded = checkIsEmbedded(qb, columnProperties.propertyPath)
     const isArray = checkIsArray(qb, columnProperties.propertyName)
 
-    const alias = fixColumnAlias(columnProperties, qb.alias, isRelation, isVirtualProperty, isEmbedded, virtualQuery, qb)
+    const alias = fixColumnAlias(
+        columnProperties,
+        qb.alias,
+        isRelation,
+        isVirtualProperty,
+        isEmbedded,
+        virtualQuery,
+        qb
+    )
     filter[column].forEach((columnFilter: Filter, index: number) => {
         const columnNamePerIteration = `${columnProperties.column}${index}`
         const condition = generatePredicateCondition(

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -167,7 +167,7 @@ export function getMissingPrimaryKeyColumns(qb: SelectQueryBuilder<any>, transfo
 
     for (const pk of mainEntityPrimaryKeys) {
         const columnProperties = getPropertiesByColumnName(pk)
-        const pkAlias = fixColumnAlias(columnProperties, qb.alias, false)
+        const pkAlias = fixColumnAlias(columnProperties, qb.alias, false, false, false, undefined, qb)
 
         if (!transformedCols.includes(pkAlias)) {
             missingPrimaryKeys.push(pkAlias)
@@ -318,8 +318,44 @@ export function fixColumnAlias(
     isRelation = false,
     isVirtualProperty = false,
     isEmbedded = false,
-    query?: ColumnMetadata['query']
+    query?: ColumnMetadata['query'],
+    qb?: SelectQueryBuilder<unknown>
 ): string {
+    let jsonbResolution: JsonbPathResolution | undefined
+    if (qb) {
+        jsonbResolution = resolveJsonbPath(qb, properties.column)
+    }
+
+    if (jsonbResolution && jsonbResolution.isJsonb) {
+        const baseColumnProperties = getPropertiesByColumnName(
+            [...jsonbResolution.relationPath, jsonbResolution.jsonbColumn].join('.')
+        )
+        const baseAlias = fixColumnAlias(
+            baseColumnProperties,
+            alias,
+            jsonbResolution.relationPath.length > 0,
+            isVirtualProperty,
+            isEmbedded,
+            query
+        )
+
+        if (jsonbResolution.jsonPath.length === 0) {
+            return baseAlias
+        }
+
+        const dbType = qb.connection.options.type
+        if (dbType === 'postgres' || dbType === 'cockroachdb') {
+            const pathLiteral = jsonbResolution.jsonPath.join(',')
+            return `${baseAlias} #>> '{${pathLiteral}}'`
+        } else if (dbType === 'mysql' || dbType === 'mariadb') {
+            const mysqlPath = jsonbResolution.jsonPath.map((p) => `"${p}"`).join('.')
+            return `JSON_UNQUOTE(JSON_EXTRACT(${baseAlias}, '$.${mysqlPath}'))`
+        } else {
+            const sqlitePath = jsonbResolution.jsonPath.map((p) => `"${p}"`).join('.')
+            return `json_extract(${baseAlias}, '$.${sqlitePath}')`
+        }
+    }
+
     if (isRelation) {
         if (isVirtualProperty && query) {
             return `(${query(`${alias}_${properties.propertyPath}_rel`)})` // () is needed to avoid parameter conflict

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -39,6 +39,7 @@ import {
     quoteVirtualColumn,
     RelationSchema,
     RelationSchemaInput,
+    resolveJsonbPath,
     SortBy,
 } from './helper'
 import globalConfig from './global-config'
@@ -142,7 +143,8 @@ function flattenWhereAndTransform<T>(
                     isRelation,
                     isVirtualProperty,
                     isEmbedded,
-                    virtualQuery
+                    virtualQuery,
+                    queryBuilder
                 )
                 const whereClause = queryBuilder['createWhereConditionExpression'](
                     queryBuilder['getWherePredicateCondition'](alias, value)
@@ -598,7 +600,8 @@ export async function paginate<T extends ObjectLiteral>(
                     isRelation,
                     isVirtualProperty,
                     isEmbedded,
-                    virtualQuery
+                    virtualQuery,
+                    queryBuilder
                 )
 
                 // Find column metadata to determine type for proper cursor handling
@@ -689,18 +692,34 @@ export async function paginate<T extends ObjectLiteral>(
             const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(queryBuilder, columnProperties)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
             const isEmbedded = checkIsEmbedded(queryBuilder, columnProperties.propertyPath)
-            let alias = fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, isVirtualProperty, isEmbedded)
+            const jsonbResolution = resolveJsonbPath(queryBuilder, columnProperties.column)
+            const isJsonbPath = jsonbResolution.isJsonb && jsonbResolution.jsonPath.length > 0
 
-            if (isVirtualProperty && virtualQuery && !isMySqlOrMariaDb) {
-                const subqueryExpr = fixColumnAlias(
-                    columnProperties,
-                    queryBuilder.alias,
-                    isRelation,
-                    isVirtualProperty,
-                    isEmbedded,
-                    virtualQuery
-                )
-                const vcSortAlias = `${alias}_vc_sort`.toLowerCase()
+            let alias = fixColumnAlias(
+                columnProperties,
+                queryBuilder.alias,
+                isRelation,
+                isVirtualProperty,
+                isEmbedded,
+                undefined,
+                queryBuilder
+            )
+
+            if ((isVirtualProperty && virtualQuery && !isMySqlOrMariaDb) || isJsonbPath) {
+                const subqueryExpr = isJsonbPath
+                    ? alias // fixColumnAlias already returns the extraction expression
+                    : fixColumnAlias(
+                          columnProperties,
+                          queryBuilder.alias,
+                          isRelation,
+                          isVirtualProperty,
+                          isEmbedded,
+                          virtualQuery,
+                          queryBuilder
+                      )
+                const vcSortAlias = isJsonbPath
+                    ? `${queryBuilder.alias}_jsonb_${columnProperties.column.replace(/[^a-zA-Z0-9]/g, '_')}_sort`.toLowerCase()
+                    : `${alias}_vc_sort`.toLowerCase()
                 queryBuilder.addSelect(subqueryExpr, vcSortAlias)
                 alias = vcSortAlias
             } else if (isVirtualProperty) {
@@ -815,7 +834,7 @@ export async function paginate<T extends ObjectLiteral>(
         let cols: string[] = selectParams.reduce((cols, currentCol) => {
             const columnProperties = getPropertiesByColumnName(currentCol)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
-            cols.push(fixColumnAlias(columnProperties, queryBuilder.alias, isRelation))
+            cols.push(fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, false, false, undefined, queryBuilder))
             return cols
         }, [])
 
@@ -862,7 +881,8 @@ export async function paginate<T extends ObjectLiteral>(
                             isRelation,
                             isVirtualProperty,
                             isEmbedded,
-                            virtualQuery
+                            virtualQuery,
+                            qb
                         )
 
                         const condition: WherePredicateOperator = {
@@ -898,7 +918,8 @@ export async function paginate<T extends ObjectLiteral>(
                                         isRelation,
                                         isVirtualProperty,
                                         isEmbedded,
-                                        virtualQuery
+                                        virtualQuery,
+                                        subQb
                                     )
 
                                     const condition: WherePredicateOperator = {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -718,7 +718,10 @@ export async function paginate<T extends ObjectLiteral>(
                           queryBuilder
                       )
                 const vcSortAlias = isJsonbPath
-                    ? `${queryBuilder.alias}_jsonb_${columnProperties.column.replace(/[^a-zA-Z0-9]/g, '_')}_sort`.toLowerCase()
+                    ? `${queryBuilder.alias}_jsonb_${columnProperties.column.replace(
+                          /[^a-zA-Z0-9]/g,
+                          '_'
+                      )}_sort`.toLowerCase()
                     : `${alias}_vc_sort`.toLowerCase()
                 queryBuilder.addSelect(subqueryExpr, vcSortAlias)
                 alias = vcSortAlias
@@ -834,7 +837,9 @@ export async function paginate<T extends ObjectLiteral>(
         let cols: string[] = selectParams.reduce((cols, currentCol) => {
             const columnProperties = getPropertiesByColumnName(currentCol)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
-            cols.push(fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, false, false, undefined, queryBuilder))
+            cols.push(
+                fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, false, false, undefined, queryBuilder)
+            )
             return cols
         }, [])
 


### PR DESCRIPTION
This PR extends the existing JSONB support to work more completely across the library's features.

Previously, JSONB paths were partially handled in filter resolution, but sorting, cursor pagination, and column selection did not account for JSONB paths, they would either produce invalid SQL or silently ignore the JSON path segment.

## Changes

- `fixColumnAlias` now accepts an optional `SelectQueryBuilder` and, when provided, detects JSONB paths using `resolveJsonbPath`. It emits the correct database-specific JSON extraction expression:
  - PostgreSQL / CockroachDB: `col #>> '{key,sub}'`
  - MySQL / MariaDB: `JSON_UNQUOTE(JSON_EXTRACT(col, '$.key.sub'))`
  - SQLite: `json_extract(col, '$.key.sub')`
- `sortableColumns`, `searchableColumns`, cursor-based pagination, and `select` now all correctly handle JSONB dot-notation paths across all supported database engines.
- Fixed `parseFilter` so that `$not` is correctly applied to each expanded `$in` entry on JSONB columns, producing proper `NOT (col @> ...) AND NOT (col @> ...)` semantics.
- Updated documentation with an accurate database support matrix.

## Limitations

JSONB filtering (`$eq`, `$in`, `$contains`) relies on TypeORM's `JsonContains` operator which generates PostgreSQL `@>` containment syntax. Filtering is therefore only supported on **PostgreSQL** and **CockroachDB**. Sorting and searching on JSONB paths works across all database engines.

## Testing

The existing test suite covers filter resolution logic. Manual testing was performed against a PostgreSQL instance for sorting, filtering, and cursor pagination on both direct JSONB columns and JSONB columns accessed through relations.