### PR TITLE
feat: support ManyToMany relations in filter EXISTS subqueries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
       "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -1402,14 +1403,14 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
       "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nestjs/common": {
       "version": "11.0.11",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.11.tgz",
       "integrity": "sha512-b3zYiho5/XGCnLa7W2hHv5ecSBR1huQrXCHu6pxd+g2HY2B7sKP5CXHMv4gHYqpIqu4ClOb7Q4tLKXMp9LyLUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1",
@@ -1481,7 +1482,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
       "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
@@ -1503,6 +1503,7 @@
       "integrity": "sha512-iv6nH66i/RuRQufg5UUboQ4jQX4NuuePrYQpHB3ueiEIhJm2yLhhNYM6Y2l/76y9woW2eckbiqbzmW/JajAgeQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.0.1",
@@ -1646,7 +1647,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
       "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       },
@@ -1675,8 +1675,7 @@
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1890,6 +1889,7 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1988,6 +1988,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2226,6 +2227,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
       "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2745,6 +2747,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -3122,7 +3125,6 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
       "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -3625,6 +3627,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3680,6 +3683,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4173,8 +4177,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.5",
@@ -5189,6 +5192,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6748,6 +6752,7 @@
       "integrity": "sha512-nXbVpyoaXVmdqlKEzToFf37qzyeeh7mbiXsnoWvstSqohj88yaa/I/Rq/HEVn2QPSZEuLIJa/jSpRDyzjEx4FQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.8.0",
@@ -6992,6 +6997,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7278,7 +7284,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -7855,6 +7862,7 @@
       "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",
@@ -8041,7 +8049,6 @@
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
       "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
       }
@@ -8286,6 +8293,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8567,6 +8575,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/__tests__/cat.entity.ts
+++ b/src/__tests__/cat.entity.ts
@@ -60,9 +60,12 @@ export class CatEntity {
     @DeleteDateColumn(DateColumnNullable)
     deletedAt?: string
 
-    @ManyToMany(() => CatEntity)
+    @ManyToMany(() => CatEntity, (cat) => cat.friendOf)
     @JoinTable()
     friends: CatEntity[]
+
+    @ManyToMany(() => CatEntity, (cat) => cat.friends)
+    friendOf: CatEntity[]
 
     @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
     weightChange: number | null

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -708,7 +708,9 @@ export function addToManySubFilters<T>(
                         .map((jc) => {
                             const junctionCol = jc.databaseName
                             const relatedPk = jc.referencedColumn.databaseName
-                            return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
+                            return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(
+                                relatedPk
+                            )}`
                         })
                         .join(' AND ')
 
@@ -741,9 +743,7 @@ export function addToManySubFilters<T>(
                         }
 
                         // Correlation
-                        existsQb.andWhere(
-                            `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
-                        )
+                        existsQb.andWhere(`${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`)
                     }
                 }
             }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -688,24 +688,63 @@ export function addToManySubFilters<T>(
             } else {
                 // Perform the final correlation WHERE clause to the main query alias
                 const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
-                for (const joinColumn of joinMeta.joinColumns) {
-                    // 1. Get the raw column names from the owning metadata:
-                    const fkColumn = joinColumn.databaseName
-                    const pkColumn = joinColumn.referencedColumn.databaseName
 
-                    // 2. Get the table aliases
-                    let fkAlias: string
-                    let pkAlias: string
-                    if (parentMeta.isOwning) {
-                        pkAlias = `_rel_${relationPath[0][0]}_0`
-                        fkAlias = mainQueryAlias
-                    } else {
-                        fkAlias = `_rel_${relationPath[0][0]}_0`
-                        pkAlias = mainQueryAlias
+                if (parentMeta.isManyToMany) {
+                    // For ManyToMany, the FK columns live in the junction (join) table, not on the
+                    // related entity's table. We must JOIN the junction table into the EXISTS subquery
+                    // and correlate via it.
+                    const junctionMeta = joinMeta.junctionEntityMetadata
+                    const junctionAlias = `_junc_${relationPath[0][0]}_0`
+                    const relatedAlias = `_rel_${relationPath[0][0]}_0`
+
+                    // When accessed from the owning side:
+                    //   joinColumns        → junction → owning entity (mainQueryAlias)
+                    //   inverseJoinColumns → junction → inverse entity (relatedAlias)
+                    // When accessed from the inverse side, the roles are swapped.
+                    const toRelatedCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
+                    const toMainCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
+
+                    const junctionToRelatedConditions = toRelatedCols
+                        .map((jc) => {
+                            const junctionCol = jc.databaseName
+                            const relatedPk = jc.referencedColumn.databaseName
+                            return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
+                        })
+                        .join(' AND ')
+
+                    const junctionTarget = junctionMeta.target ?? junctionMeta.tableName
+                    existsQb.innerJoin(junctionTarget, junctionAlias, junctionToRelatedConditions)
+
+                    // Correlate the junction table back to the main query entity.
+                    for (const joinColumn of toMainCols) {
+                        const junctionCol = joinColumn.databaseName
+                        const mainPk = joinColumn.referencedColumn.databaseName
+                        existsQb.andWhere(
+                            `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(mainQueryAlias)}.${quote(mainPk)}`
+                        )
                     }
+                } else {
+                    for (const joinColumn of joinMeta.joinColumns) {
+                        // 1. Get the raw column names from the owning metadata:
+                        const fkColumn = joinColumn.databaseName
+                        const pkColumn = joinColumn.referencedColumn.databaseName
 
-                    // Correlation
-                    existsQb.andWhere(`${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`)
+                        // 2. Get the table aliases
+                        let fkAlias: string
+                        let pkAlias: string
+                        if (parentMeta.isOwning) {
+                            pkAlias = `_rel_${relationPath[0][0]}_0`
+                            fkAlias = mainQueryAlias
+                        } else {
+                            fkAlias = `_rel_${relationPath[0][0]}_0`
+                            pkAlias = mainQueryAlias
+                        }
+
+                        // Correlation
+                        existsQb.andWhere(
+                            `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
+                        )
+                    }
                 }
             }
         }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -5409,6 +5409,50 @@ describe('paginate', () => {
                 expect(result.data[4].id).toBe(cats[6].id)
             })
 
+            it('should find cats that have a friend named Garfield (ManyToMany owning side)', async () => {
+                // This test verifies that filtering on a ManyToMany relation generates valid SQL.
+                // cats[0] (Milo) has friends cats[1..6]; no other cat has friends.
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'friends.name': [FilterOperator.EQ],
+                    },
+                }
+                const query: PaginateQuery = {
+                    filter: {
+                        'friends.name': '$eq:Garfield',
+                    },
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                // Only Milo (cats[0]) has Garfield as a friend
+                expect(result.data.length).toBe(1)
+                expect(result.data[0].id).toBe(cats[0].id)
+            })
+
+            it('should find cats that are a friend of Milo (ManyToMany inverse side)', async () => {
+                // cats[0] (Milo) has friends cats[1..6]; so cats[1..6] have Milo in their friendOf relation.
+                // Filtering on friendOf.name = 'Milo' should return cats[1..6].
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'friendOf.name': [FilterOperator.EQ],
+                    },
+                }
+                const query: PaginateQuery = {
+                    filter: {
+                        'friendOf.name': `$eq:${cats[0].name}`,
+                    },
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                // cats[1..6] are friends of Milo
+                expect(result.data.length).toBe(6)
+                expect(result.data.map((c) => c.id).sort()).toEqual(cats.slice(1).map((c) => c.id).sort())
+            })
+
             describe('Advanced quantifier combinatorics', () => {
                 // None of these have been implemented yet, feel free to PR :innocent:
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -5450,7 +5450,12 @@ describe('paginate', () => {
                 const result = await paginate<CatEntity>(query, catRepo, config)
                 // cats[1..6] are friends of Milo
                 expect(result.data.length).toBe(6)
-                expect(result.data.map((c) => c.id).sort()).toEqual(cats.slice(1).map((c) => c.id).sort())
+                expect(result.data.map((c) => c.id).sort()).toEqual(
+                    cats
+                        .slice(1)
+                        .map((c) => c.id)
+                        .sort()
+                )
             })
 
             describe('Advanced quantifier combinatorics', () => {


### PR DESCRIPTION
addresses #1137 

## Summary

- Adds junction table JOIN logic to `addToManySubFilters` so that filtering on ManyToMany relations correctly correlates through the junction table instead of producing invalid SQL
- Handles both the owning side and the inverse side of ManyToMany relations
- Adds tests for filtering via `friends` (owning) and `friendOf` (inverse) ManyToMany relations on the cat entity

## Problem

Previously, filtering on a ManyToMany relation would fall into the `joinColumns` path, which is empty for ManyToMany (FK columns live in the junction table). This produced an EXISTS subquery with no ON/WHERE correlation — effectively a cross join.

## Solution

When `parentMeta.isManyToMany` is true, the code now:
1. Resolves the junction entity metadata
2. JOINs the junction table into the EXISTS subquery, correlating it to the related entity
3. Adds a WHERE clause correlating the junction table back to the main query alias

Both owning-side and inverse-side access are handled by selecting the correct `joinColumns` / `inverseJoinColumns` from the always-owning `joinMeta`.