### PR TITLE
feat: add AND-mode to-many filtering via per-value EXISTS subqueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,48 @@ Assume `CatEntity` has a one‑to‑many relation `toys: CatToyEntity[]` where `
   GET /cats?filter.toys.name=$any:$not:$eq:Squeaky
   ```
 
+### AND-mode: entity must have ALL of the specified related values
+
+Use the `$and` comparator to require that a parent entity has **all** of the specified related values.
+Each `$and` value produces a separate correlated EXISTS subquery, ANDed on the outer query.
+
+Enable it in `filterableColumns`:
+
+```typescript
+filterableColumns: {
+  'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+}
+```
+
+- Cat must have **both** a toy named "Ball" **and** a toy named "Mouse":
+
+  ```url
+  GET /cats?filter.toys.name=$and:Ball&filter.toys.name=$and:Mouse
+  ```
+
+- Cat must have a toy named "Ball" **and** be friends with a cat named "Garfield" (two independent to-many paths):
+
+  ```url
+  GET /cats?filter.toys.name=$and:Ball&filter.friends.name=$and:Garfield
+  ```
+
+**Restrictions and performance notes**:
+
+- `$and` may only be used on to-many relationship columns (one-to-many or many-to-many).
+- `$and` values may not be mixed with non-`$and` values on the same sub-column.
+- `$and` may not be combined with `$none` or `$all` quantifiers.
+- Each `$and` value adds one correlated EXISTS subquery. For N values and a relation path of depth D, this produces N × D joins. The default cap is 20 values per sub-column; override with `maxAndValues` in `PaginateConfig`.
+
+```typescript
+const config: PaginateConfig<CatEntity> = {
+  sortableColumns: ['id'],
+  filterableColumns: {
+    'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+  },
+  maxAndValues: 10, // optional, default is 20
+}
+```
+
 ## Usage with Eager Loading
 
 Eager loading should work with TypeORM's eager property out of the box:

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -105,31 +105,19 @@ describe('parseFilter $and gating', () => {
     })
 
     it('blocks $and when FilterComparator.AND is not in filterableColumns', () => {
-        const result = parseFilter(
-            { path: '', filter: { name: '$and:Ball' } },
-            { name: [FilterOperator.EQ] },
-            qb
-        )
+        const result = parseFilter({ path: '', filter: { name: '$and:Ball' } }, { name: [FilterOperator.EQ] }, qb)
         // The $and token should be filtered out
         expect(!result.name || result.name.length === 0).toBe(true)
     })
 
     it('allows a plain filter (no explicit $and) even without FilterComparator.AND in filterableColumns', () => {
-        const result = parseFilter(
-            { path: '', filter: { name: 'Ball' } },
-            { name: [FilterOperator.EQ] },
-            qb
-        )
+        const result = parseFilter({ path: '', filter: { name: 'Ball' } }, { name: [FilterOperator.EQ] }, qb)
         expect(result.name).toBeDefined()
         expect(result.name.length).toBe(1)
     })
 
     it('allows $and when filterableColumns is true (all allowed)', () => {
-        const result = parseFilter(
-            { path: '', filter: { name: '$and:Ball' } },
-            { name: true },
-            qb
-        )
+        const result = parseFilter({ path: '', filter: { name: '$and:Ball' } }, { name: true }, qb)
         expect(result.name).toBeDefined()
         expect(result.name.length).toBe(1)
     })

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -1,4 +1,12 @@
-import { parseFilter } from './filter'
+import {
+    FilterComparator,
+    FilterOperator,
+    FilterQuantifier,
+    hasExplicitAndComparator,
+    parseFilter,
+    parseFilterToken,
+    TYPEORM_PARAM_REGEX,
+} from './filter'
 import { isISODate } from './helper'
 
 function createQueryBuilderMock(columns: Array<{ propertyName: string; type: unknown }>): any {
@@ -36,5 +44,169 @@ describe('parseFilter', () => {
 describe('isISODate', () => {
     it('returns false when a valid ISO date is only part of the input', () => {
         expect(isISODate('prefix 2024-01-01T12:30:45Z suffix')).toBe(false)
+    })
+})
+
+describe('parseFilterToken', () => {
+    it('parses a plain value with default AND comparator', () => {
+        const token = parseFilterToken('Ball')
+        expect(token).not.toBeNull()
+        expect(token!.comparator).toBe(FilterComparator.AND)
+        expect(token!.value).toBe('Ball')
+    })
+
+    it('parses $and comparator explicitly', () => {
+        const token = parseFilterToken('$and:Ball')
+        expect(token).not.toBeNull()
+        expect(token!.comparator).toBe(FilterComparator.AND)
+        expect(token!.value).toBe('Ball')
+    })
+
+    it('parses $and with an explicit operator', () => {
+        const token = parseFilterToken('$and:$eq:Ball')
+        expect(token).not.toBeNull()
+        expect(token!.comparator).toBe(FilterComparator.AND)
+        expect(token!.operator).toBe(FilterOperator.EQ)
+        expect(token!.value).toBe('Ball')
+    })
+
+    it('parses $and combined with a quantifier', () => {
+        const token = parseFilterToken('$none:$and:$eq:Ball')
+        expect(token).not.toBeNull()
+        expect(token!.quantifier).toBe(FilterQuantifier.NONE)
+        expect(token!.comparator).toBe(FilterComparator.AND)
+        expect(token!.value).toBe('Ball')
+    })
+})
+
+describe('parseFilter $and gating', () => {
+    const qb = {
+        expressionMap: {
+            mainAlias: {
+                metadata: {
+                    columns: [{ propertyName: 'name', type: String }],
+                    relations: [],
+                    findColumnWithPropertyPath: () => undefined,
+                    findColumnWithPropertyName: (p: string) =>
+                        p === 'name' ? { propertyName: 'name', type: String } : undefined,
+                },
+            },
+        },
+    } as any
+
+    it('allows $and when FilterComparator.AND is in filterableColumns', () => {
+        const result = parseFilter(
+            { path: '', filter: { name: '$and:Ball' } },
+            { name: [FilterOperator.EQ, FilterComparator.AND] },
+            qb
+        )
+        expect(result.name).toBeDefined()
+        expect(result.name.length).toBe(1)
+    })
+
+    it('blocks $and when FilterComparator.AND is not in filterableColumns', () => {
+        const result = parseFilter(
+            { path: '', filter: { name: '$and:Ball' } },
+            { name: [FilterOperator.EQ] },
+            qb
+        )
+        // The $and token should be filtered out
+        expect(!result.name || result.name.length === 0).toBe(true)
+    })
+
+    it('allows a plain filter (no explicit $and) even without FilterComparator.AND in filterableColumns', () => {
+        const result = parseFilter(
+            { path: '', filter: { name: 'Ball' } },
+            { name: [FilterOperator.EQ] },
+            qb
+        )
+        expect(result.name).toBeDefined()
+        expect(result.name.length).toBe(1)
+    })
+
+    it('allows $and when filterableColumns is true (all allowed)', () => {
+        const result = parseFilter(
+            { path: '', filter: { name: '$and:Ball' } },
+            { name: true },
+            qb
+        )
+        expect(result.name).toBeDefined()
+        expect(result.name.length).toBe(1)
+    })
+})
+
+describe('parameter rename regex (TYPEORM_PARAM_REGEX)', () => {
+    // Helper that applies the module-level regex (must reset lastIndex before each use).
+    const rename = (s: string, suffix: string) => {
+        TYPEORM_PARAM_REGEX.lastIndex = 0
+        return s.replace(TYPEORM_PARAM_REGEX, (_, spread, name) => `:${spread ?? ''}${name}${suffix}`)
+    }
+
+    it('renames a simple named parameter', () => {
+        expect(rename(':name_1', '_e0')).toBe(':name_1_e0')
+    })
+
+    it('renames multiple parameters in one string', () => {
+        expect(rename(':foo = :bar', '_e1')).toBe(':foo_e1 = :bar_e1')
+    })
+
+    it('does not rename PostgreSQL :: cast syntax', () => {
+        expect(rename('col::text = :value', '_e0')).toBe('col::text = :value_e0')
+    })
+
+    it('does not rename :: in the middle of an expression', () => {
+        expect(rename(':param::integer > 0', '_e0')).toBe(':param_e0::integer > 0')
+    })
+
+    it('renames embedded-path parameters (containing dots)', () => {
+        expect(rename(':size.height0', '_e0')).toBe(':size.height0_e0')
+    })
+
+    it('renames :...spread parameters (used by $in)', () => {
+        expect(rename(':...vals', '_e0')).toBe(':...vals_e0')
+    })
+
+    it('renames :...spread alongside a cast', () => {
+        expect(rename('col IN (:...vals) AND col2::text = :other', '_e1')).toBe(
+            'col IN (:...vals_e1) AND col2::text = :other_e1'
+        )
+    })
+
+    it('handles jsonb cast: :param::jsonb is renamed correctly', () => {
+        expect(rename('col @> :json::jsonb', '_e0')).toBe('col @> :json_e0::jsonb')
+    })
+})
+
+describe('hasExplicitAndComparator', () => {
+    it('returns true for $and:Ball', () => {
+        expect(hasExplicitAndComparator('$and:Ball')).toBe(true)
+    })
+
+    it('returns true for $and:$eq:Ball', () => {
+        expect(hasExplicitAndComparator('$and:$eq:Ball')).toBe(true)
+    })
+
+    it('returns true for $none:$and:Ball', () => {
+        expect(hasExplicitAndComparator('$none:$and:Ball')).toBe(true)
+    })
+
+    it('returns false for a plain value (no $and prefix)', () => {
+        expect(hasExplicitAndComparator('Ball')).toBe(false)
+    })
+
+    it('returns false for $eq:Ball (default AND comparator, not explicit)', () => {
+        expect(hasExplicitAndComparator('$eq:Ball')).toBe(false)
+    })
+
+    it('returns false for $eq:$and (value is the literal string $and, not the comparator)', () => {
+        // parseFilterToken sees $eq as operator, value = '$and' — comparator stays default AND
+        // but $and is NOT in the consumed prefix as a comparator token.
+        expect(hasExplicitAndComparator('$eq:$and')).toBe(false)
+    })
+
+    it('returns true for bare $and (no value after colon — user explicitly wrote $and)', () => {
+        // parseFilterToken: $and is consumed as comparator, value = undefined.
+        // hasExplicitAndComparator should still return true (the user wrote $and explicitly).
+        expect(hasExplicitAndComparator('$and')).toBe(true)
     })
 })

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -86,6 +86,29 @@ export function isComparator(value: unknown): value is FilterComparator {
     return values(FilterComparator).includes(value as any)
 }
 
+/**
+ * Returns true when the raw filter string explicitly carries the `$and` comparator token.
+ *
+ * This is distinct from the default AND comparator that every token carries implicitly —
+ * we only want to enter AND-mode when the user deliberately wrote `$and:` in the filter value.
+ * Using `parseFilterToken` (rather than a naive substring split) ensures that `$and` embedded
+ * inside a user value (e.g. `$eq:$and`) is not misidentified as the comparator.
+ *
+ * Must be called after `parseFilterToken` is defined (hoisting applies to function declarations).
+ */
+export function hasExplicitAndComparator(raw: string): boolean {
+    const token = parseFilterToken(raw)
+    if (!token) return false
+    if (token.comparator !== FilterComparator.AND) return false
+    // The default token comparator is AND, so we must confirm the user actually wrote `$and` as a
+    // colon-delimited token segment. We reconstruct the consumed prefix (everything before the value)
+    // and check whether `$and` appears in it as a discrete segment.
+    // This correctly rejects `$eq:$and` (value = `$and`, prefix = `$eq:`) and accepts `$and:Ball`.
+    const valueSuffix = token.value !== undefined ? `:${token.value}` : ''
+    const prefix = valueSuffix ? raw.slice(0, raw.length - valueSuffix.length) : raw
+    return prefix.split(':').some((seg) => seg === FilterComparator.AND)
+}
+
 export const OperatorSymbolToFunction = new Map<
     FilterOperator | FilterSuffix,
     (...args: any[]) => FindOperator<string>
@@ -107,6 +130,28 @@ export const OperatorSymbolToFunction = new Map<
 type Filter = { quantifier: FilterQuantifier; comparator: FilterComparator; findOperator: FindOperator<string> }
 type ColumnFilters = { [columnName: string]: Filter[] }
 type ColumnJoinMethods = { [columnName: string]: JoinMethod }
+
+/**
+ * Matches TypeORM named parameters (`:name` and `:...name` spread form) while skipping
+ * PostgreSQL cast syntax (`::type`).
+ *
+ * TypeORM parameter names may contain letters, digits, underscores, and dots (the latter
+ * for embedded-property paths, e.g. `size.height0`). The pattern captures the full name
+ * including any embedded-path dots.
+ *
+ * Capture groups:
+ *   1 — optional `...` spread prefix (present for IN parameters)
+ *   2 — parameter name (may contain dots for embedded paths)
+ *
+ * Examples:
+ *   `:name`          → matches, spread=undefined, name='name'
+ *   `:...vals`       → matches, spread='...', name='vals'
+ *   `:size.height0`  → matches, spread=undefined, name='size.height0'
+ *   `col::text`      → no match (lookbehind rejects `::`)
+ *   `:param::int`    → matches `:param`, skips `::int`
+ */
+/** @internal Exported for testing only. */
+export const TYPEORM_PARAM_REGEX = /(?<!:):(\.\.\.)?([a-zA-Z0-9_.]+)/g
 
 export interface FilterToken {
     quantifier: FilterQuantifier
@@ -336,6 +381,12 @@ export function parseFilter<T>(
                 if (token.quantifier !== FilterQuantifier.ANY && !allowedOperators.includes(token.quantifier)) {
                     continue
                 }
+                // Gate the $and comparator: only allow it if explicitly listed in filterableColumns.
+                // The default token comparator is AND (used for normal andWhere), so we must check
+                // whether $and was explicitly present in the raw filter string, not just the token default.
+                if (!allowedOperators.includes(FilterComparator.AND) && hasExplicitAndComparator(raw)) {
+                    continue
+                }
             }
 
             const params: (typeof filter)[0][0] = {
@@ -535,16 +586,33 @@ function findFirstToManyRelationship(
         }
 }
 
+export interface AddFilterOptions {
+    /**
+     * Maximum number of `$and` values allowed per sub-column in a single to-many filter.
+     * Each value produces a separate correlated EXISTS subquery, so large values have a
+     * linear performance cost. Defaults to 20.
+     */
+    maxAndValues?: number
+    /**
+     * When false, skips the validation that rejects `$and` on non-to-many columns.
+     * Set to false when calling `addFilter` recursively for EXISTS sub-queries, where the
+     * entity metadata is the leaf entity and the to-many check would incorrectly throw.
+     * @internal
+     */
+    validateAndComparator?: boolean
+}
+
 export function addFilter<T>(
     qb: SelectQueryBuilder<T>,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true }
+    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    opts: AddFilterOptions = {}
 ) {
     const mainMetadata = qb.expressionMap.mainAlias.metadata
     const filter = parseFilter(query, filterableColumns, qb)
 
     addDirectFilters(qb, filter)
-    addToManySubFilters(qb, filter, query, filterableColumns)
+    addToManySubFilters(qb, filter, query, filterableColumns, opts)
 
     // Direct filters require to be joined, so pass the join information back up to the main pagination builder
     // (or the parent filter query in case of subfilters)
@@ -601,11 +669,32 @@ export function addDirectFilters<T>(qb: SelectQueryBuilder<T>, filter: ColumnFil
     }
 }
 
+/**
+ * Adds correlated EXISTS subqueries to `qb` for all to-many relationship filters in `filter`.
+ *
+ * **AND-mode (`$and` comparator)**
+ *
+ * When a sub-column filter uses the `$and` comparator (e.g. `filter[toys.name]=$and:Ball`),
+ * each distinct `$and` value produces a separate correlated EXISTS subquery, ANDed on the
+ * outer query. This is the only correct way to express "entity has ALL of these related values"
+ * — a single EXISTS with AND conditions on the same column is always false on a single row.
+ *
+ * **Performance note**: each `$and` value adds one correlated EXISTS with the full join chain
+ * for that relation path. For a relation path of depth D and N `$and` values, this produces
+ * N × D joins. The `maxAndValues` option (default 20) caps N to limit query complexity.
+ *
+ * **Restrictions**:
+ * - `$and` may only be used on to-many relationship columns.
+ * - `$and` values may not be mixed with non-`$and` values on the same sub-column.
+ * - `$and` may not be combined with `$none` or `$all` quantifiers.
+ * - `$and` may only be applied to a single sub-column per relation path at a time.
+ */
 export function addToManySubFilters<T>(
     qb: SelectQueryBuilder<T>,
     filter: ColumnFilters,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true }
+    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    { maxAndValues = 20, validateAndComparator = true }: AddFilterOptions = {}
 ) {
     const dbType = qb.connection.options.type
     const quote = (column: string) => quoteColumn(column, ['mysql', 'mariadb'].includes(dbType))
@@ -616,6 +705,28 @@ export function addToManySubFilters<T>(
     const existsFilters = filterEntries.map(([key]) => findFirstToManyRelationship(key, mainMetadata)).filter(Boolean)
     // Find all the different toMany starting paths
     const toManyPaths = [...new Set(existsFilters.map((f) => f.path.join('.')))]
+
+    // Validate that $and is not used on scalar (non-to-many) columns — it has no meaningful
+    // semantics there and would produce always-false conditions (e.g. WHERE name = 'a' AND name = 'b').
+    // Skip this validation when called recursively for EXISTS subqueries (validateAndComparator = false),
+    // because the sub-filter keys are already stripped of the relation prefix and the entity metadata
+    // is the leaf entity, so the to-many check would incorrectly throw.
+    if (validateAndComparator) {
+        for (const [key, rawValues] of Object.entries(query.filter ?? {})) {
+            const isToMany = findFirstToManyRelationship(key, mainMetadata) != null
+            if (!isToMany) {
+                const values = Array.isArray(rawValues) ? rawValues : [rawValues]
+                const hasAndValue = values.some((v) => hasExplicitAndComparator(v))
+                if (hasAndValue) {
+                    throw new Error(
+                        `The $and comparator can only be used on to-many relationship columns. ` +
+                            `Column "${key}" is not a to-many relationship.`
+                    )
+                }
+            }
+        }
+    }
+
     const toManyRelations = toManyPaths.map(
         (path) => [path, existsFilters.find((f) => f.path.join('.') === path).relation] as const
     )
@@ -623,14 +734,14 @@ export function addToManySubFilters<T>(
     for (const [path, relation] of toManyRelations) {
         const mainQueryAlias = qb.alias
         const relationPath = getRelationPath(path, mainMetadata)
-        const toManyAlias = `_rel_${relationPath[relationPath.length - 1][0]}_${relationPath.length - 1}`
-
         // 1. Create the EXISTS subquery, starting from the toMany entity
         const existsMetadata = relation.inverseEntityMetadata
 
-        if (existsMetadata.deleteDateColumn) {
-            //existsQb.andWhere(`"${toManyAlias}"."${existsMetadata.deleteDateColumn.databaseName}" IS NULL`)
-        }
+        // Slug used in alias/parameter suffixes to scope them to this relation path.
+        // Using the path (e.g. "toys" → "toys", "cat.toys" → "cat_toys") ensures that two
+        // independent to-many paths in the same outer query never share alias or parameter names,
+        // even when both use existsIndex=0 (OR-mode) or overlapping sub-column names.
+        const pathSlug = path.replace(/\./g, '_')
 
         // 2. Extract sub-filters for this path.
         // If any sub-filter entry uses the $and comparator, we must emit one correlated EXISTS
@@ -643,10 +754,7 @@ export function addToManySubFilters<T>(
         const andValuesBySubColumn: { [subCol: string]: string[] } = {}
         for (const [subCol, rawValues] of Object.entries(subQuery.filter ?? {})) {
             const values = Array.isArray(rawValues) ? rawValues : [rawValues]
-            const andValues = values.filter((v) => {
-                const token = parseFilterToken(v)
-                return token && token.comparator === FilterComparator.AND && token.quantifier === FilterQuantifier.ANY
-            })
+            const andValues = values.filter((v) => hasExplicitAndComparator(v))
             if (andValues.length >= 1) {
                 andValuesBySubColumn[subCol] = andValues
             }
@@ -660,19 +768,41 @@ export function addToManySubFilters<T>(
         // Build a helper that constructs and correlates a single EXISTS subquery for this path.
         // existsIndex must be unique per EXISTS emitted for this path to avoid alias collisions
         // when multiple EXISTS subqueries are added to the same outer query (AND-mode).
+        // The pathSlug is included in all aliases and parameter names so that two independent
+        // to-many paths (e.g. "toys" and "friends") never collide even when both use existsIndex=0.
         const buildExistsQb = (extraSubQuery: PaginateQuery, existsIndex = 0) => {
-            const relAlias = (name: string, depth: number) => `_rel_${name}_${depth}_e${existsIndex}`
-            const juncAlias = (name: string, depth: number) => `_junc_${name}_${depth}_e${existsIndex}`
+            const relAlias = (name: string, depth: number) => `_rel_${name}_${depth}_${pathSlug}_e${existsIndex}`
+            const juncAlias = (name: string, depth: number) => `_junc_${name}_${depth}_${pathSlug}_e${existsIndex}`
             const leafAlias = relAlias(relationPath[relationPath.length - 1][0], relationPath.length - 1)
             const existsQb = qb.connection.createQueryBuilder(existsMetadata.target as any, leafAlias)
 
-            const subJoins = addFilter(existsQb, extraSubQuery, subFilterableColumns)
+            const subJoins = addFilter(existsQb, extraSubQuery, subFilterableColumns, { validateAndComparator: false })
 
-            // 3. Add the sub relationship joins to the EXISTS subquery
+            // Step 3: Add the sub relationship joins to the EXISTS subquery.
             const relationsSchema = mergeRelationSchema(createRelationSchema(Object.keys(subJoins)))
             addRelationsFromSchema(existsQb, relationsSchema, {}, 'innerJoin')
 
-            // 4. Build the chain of joins that backtracks our toMany relationship to the root.
+            // Step 4: Build the chain of joins that backtracks our toMany relationship to the root.
+            buildSubqueryJoinChain(existsQb, relAlias, juncAlias)
+
+            // Step 5: Rename all parameters to include a path+index suffix, preventing collisions
+            // when multiple EXISTS subqueries share the outer query's parameter namespace.
+            const suffix = `_${pathSlug}_e${existsIndex}`
+            renameSubqueryParameters(existsQb, suffix)
+
+            return existsQb
+        }
+
+        /**
+         * Adds the join chain that correlates the EXISTS subquery back to the root entity.
+         * Iterates from the deepest relation segment to the root, adding INNER JOINs for
+         * intermediate relations and a correlated WHERE clause for the root relation.
+         */
+        function buildSubqueryJoinChain(
+            existsQb: SelectQueryBuilder<any>,
+            relAlias: (name: string, depth: number) => string,
+            juncAlias: (name: string, depth: number) => string
+        ) {
             for (let i = relationPath.length - 1; i >= 0; i--) {
                 const [, meta] = relationPath[i]
 
@@ -703,107 +833,170 @@ export function addToManySubFilters<T>(
                         onConditions
                     )
                 } else {
-                    // --- Root correlation ---
-                    const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
+                    correlateManyToManyOrFk(existsQb, parentMeta, relAlias, juncAlias)
+                }
+            }
+        }
 
-                    if (parentMeta.isManyToMany) {
-                        // For ManyToMany, the FK columns live in the junction (join) table, not on the
-                        // related entity's table. We must JOIN the junction table into the EXISTS subquery
-                        // and correlate via it.
-                        const junctionMeta = joinMeta.junctionEntityMetadata
-                        const junctionAlias = juncAlias(relationPath[0][0], 0)
-                        const relatedAlias = relAlias(relationPath[0][0], 0)
+        /**
+         * Adds the root correlation clause to the EXISTS subquery.
+         * For ManyToMany relations, JOINs the junction table and correlates via it.
+         * For OneToMany / ManyToOne relations, adds a direct FK = PK WHERE clause.
+         */
+        function correlateManyToManyOrFk(
+            existsQb: SelectQueryBuilder<any>,
+            parentMeta: RelationMetadata,
+            relAlias: (name: string, depth: number) => string,
+            juncAlias: (name: string, depth: number) => string
+        ) {
+            // --- Root correlation ---
+            //
+            // `joinMeta` is always the owning side of the relation, regardless of which side
+            // the filter is expressed from. This is because TypeORM stores join column metadata
+            // (including junction table metadata for ManyToMany) only on the owning side.
+            //
+            // Example (ManyToMany, inverse side):
+            //   Cat.friends (owning) ←→ Cat.friendOf (inverse)
+            //   Filtering on "friendOf.name": parentMeta = friendOf (inverse, !isOwning)
+            //   joinMeta = parentMeta.inverseRelation = friends (owning)
+            //   toRelatedCols = joinMeta.joinColumns  (junction → owning entity = friendOf side)
+            //   toMainCols    = joinMeta.inverseJoinColumns (junction → inverse entity = Cat being filtered)
+            if (!parentMeta.isOwning && !parentMeta.inverseRelation) {
+                throw new Error(
+                    `Cannot build EXISTS subquery for ManyToMany relation "${path}": ` +
+                        `the relation has no inverse side defined. ` +
+                        `Ensure the @ManyToMany decorator on the inverse entity references this relation.`
+                )
+            }
+            const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
 
-                        // When accessed from the owning side:
-                        //   joinColumns        → junction → owning entity (mainQueryAlias)
-                        //   inverseJoinColumns → junction → inverse entity (relatedAlias)
-                        // When accessed from the inverse side, the roles are swapped.
-                        const toRelatedCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
-                        const toMainCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
+            if (parentMeta.isManyToMany) {
+                // For ManyToMany, the FK columns live in the junction (join) table, not on the
+                // related entity's table. We must JOIN the junction table into the EXISTS subquery
+                // and correlate via it.
+                const junctionMeta = joinMeta.junctionEntityMetadata
+                const junctionAlias = juncAlias(relationPath[0][0], 0)
+                const relatedAlias = relAlias(relationPath[0][0], 0)
 
-                        const junctionToRelatedConditions = toRelatedCols
-                            .map((jc) => {
-                                const junctionCol = jc.databaseName
-                                const relatedPk = jc.referencedColumn.databaseName
-                                return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
-                            })
-                            .join(' AND ')
+                // Column role mapping (always relative to `joinMeta`, which is the owning side):
+                //   joinMeta.joinColumns        → junction columns pointing to the owning entity
+                //   joinMeta.inverseJoinColumns → junction columns pointing to the inverse entity
+                //
+                // When filtering from the owning side (parentMeta.isOwning):
+                //   toRelatedCols = inverseJoinColumns → junction → related entity (EXISTS root)
+                //   toMainCols    = joinColumns        → junction → main query entity
+                //
+                // When filtering from the inverse side (!parentMeta.isOwning):
+                //   joinMeta = parentMeta.inverseRelation (the owning side)
+                //   toRelatedCols = joinMeta.joinColumns        → junction → owning entity (EXISTS root)
+                //   toMainCols    = joinMeta.inverseJoinColumns → junction → main query entity
+                const toRelatedCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
+                const toMainCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
 
-                        const junctionTarget = junctionMeta.target ?? junctionMeta.tableName
-                        existsQb.innerJoin(junctionTarget, junctionAlias, junctionToRelatedConditions)
+                const junctionToRelatedConditions = toRelatedCols
+                    .map((jc) => {
+                        const junctionCol = jc.databaseName
+                        const relatedPk = jc.referencedColumn.databaseName
+                        return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
+                    })
+                    .join(' AND ')
 
-                        for (const joinColumn of toMainCols) {
-                            const junctionCol = joinColumn.databaseName
-                            const mainPk = joinColumn.referencedColumn.databaseName
-                            existsQb.andWhere(
-                                `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(mainQueryAlias)}.${quote(mainPk)}`
-                            )
-                        }
+                const junctionTarget = junctionMeta.target ?? junctionMeta.tableName
+                existsQb.innerJoin(junctionTarget, junctionAlias, junctionToRelatedConditions)
+
+                for (const joinColumn of toMainCols) {
+                    const junctionCol = joinColumn.databaseName
+                    const mainPk = joinColumn.referencedColumn.databaseName
+                    existsQb.andWhere(
+                        `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(mainQueryAlias)}.${quote(mainPk)}`
+                    )
+                }
+            } else {
+                for (const joinColumn of joinMeta.joinColumns) {
+                    const fkColumn = joinColumn.databaseName
+                    const pkColumn = joinColumn.referencedColumn.databaseName
+                    let fkAlias: string
+                    let pkAlias: string
+                    if (parentMeta.isOwning) {
+                        pkAlias = relAlias(relationPath[0][0], 0)
+                        fkAlias = mainQueryAlias
                     } else {
-                        for (const joinColumn of joinMeta.joinColumns) {
-                            const fkColumn = joinColumn.databaseName
-                            const pkColumn = joinColumn.referencedColumn.databaseName
-                            let fkAlias: string
-                            let pkAlias: string
-                            if (parentMeta.isOwning) {
-                                pkAlias = relAlias(relationPath[0][0], 0)
-                                fkAlias = mainQueryAlias
+                        fkAlias = relAlias(relationPath[0][0], 0)
+                        pkAlias = mainQueryAlias
+                    }
+                    existsQb.andWhere(
+                        `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
+                    )
+                }
+            }
+        }
+
+        /**
+         * Renames all TypeORM named parameters in the EXISTS subquery by appending `suffix`.
+         * This prevents parameter name collisions when multiple EXISTS subqueries share the
+         * outer query's parameter namespace (AND-mode emits one EXISTS per `$and` value).
+         *
+         * Handles both simple parameters (`:name`) and spread parameters (`:...name` for IN),
+         * and correctly skips PostgreSQL cast syntax (`::type`).
+         */
+        function renameSubqueryParameters(existsQb: SelectQueryBuilder<any>, suffix: string) {
+            const oldParams = { ...existsQb.expressionMap.parameters }
+            existsQb.expressionMap.parameters = {}
+            for (const [key, value] of Object.entries(oldParams)) {
+                existsQb.expressionMap.parameters[key + suffix] = value
+            }
+            // Use the module-level TYPEORM_PARAM_REGEX (handles both :name and :...name spread form,
+            // skips PostgreSQL ::type cast syntax). Must reset lastIndex since the regex is stateful (flag g).
+            const renameParamsInString = (s: string) => {
+                TYPEORM_PARAM_REGEX.lastIndex = 0
+                return s.replace(TYPEORM_PARAM_REGEX, (_, spread, name) => `:${spread ?? ''}${name}${suffix}`)
+            }
+            const renameParamsInCondition = (condition: any): void => {
+                if (typeof condition === 'string') {
+                    // Top-level string conditions are handled by the caller (the `for` loop over
+                    // `existsQb.expressionMap.wheres` below). Nested string conditions that appear
+                    // inside a `WhereClause.condition` object are handled by the `condition.condition`
+                    // branch below. This branch is a no-op guard — TypeORM never passes a bare string
+                    // here in practice, but the type allows it.
+                    return
+                }
+                if (Array.isArray(condition)) {
+                    // Arrays cannot be mutated element-by-element for strings (immutable),
+                    // so we map over the array and replace string items directly.
+                    for (let i = 0; i < condition.length; i++) {
+                        if (typeof condition[i] === 'string') {
+                            condition[i] = renameParamsInString(condition[i])
+                        } else {
+                            renameParamsInCondition(condition[i])
+                        }
+                    }
+                    return
+                }
+                if (condition && typeof condition === 'object') {
+                    if (typeof condition.condition === 'string') {
+                        condition.condition = renameParamsInString(condition.condition)
+                    } else if (condition.condition) {
+                        renameParamsInCondition(condition.condition)
+                    }
+                    // Also rename in nested children arrays (e.g. Brackets with multiple clauses)
+                    if (Array.isArray(condition.wheres)) {
+                        for (const child of condition.wheres) {
+                            if (typeof child.condition === 'string') {
+                                child.condition = renameParamsInString(child.condition)
                             } else {
-                                fkAlias = relAlias(relationPath[0][0], 0)
-                                pkAlias = mainQueryAlias
+                                renameParamsInCondition(child.condition)
                             }
-                            existsQb.andWhere(
-                                `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
-                            )
                         }
                     }
                 }
             }
-
-            // Rename all parameters in the EXISTS subquery to include the existsIndex suffix,
-            // preventing parameter name collisions when multiple EXISTS subqueries are added
-            // to the same outer query (AND-mode emits one EXISTS per $and value).
-            if (existsIndex > 0) {
-                const suffix = `_e${existsIndex}`
-                const oldParams = { ...existsQb.expressionMap.parameters }
-                existsQb.expressionMap.parameters = {}
-                for (const [key, value] of Object.entries(oldParams)) {
-                    existsQb.expressionMap.parameters[key + suffix] = value
-                }
-                const renameParamsInCondition = (condition: any, suffix: string): void => {
-                    if (typeof condition === 'string') {
-                        return // handled at the where level
-                    }
-                    if (Array.isArray(condition)) {
-                        for (const item of condition) {
-                            renameParamsInCondition(item, suffix)
-                        }
-                        return
-                    }
-                    if (condition && typeof condition === 'object') {
-                        if (typeof condition.condition === 'string') {
-                            condition.condition = condition.condition.replace(
-                                /:([a-zA-Z0-9_]+)\b/g,
-                                (_, name) => `:${name}${suffix}`
-                            )
-                        } else if (condition.condition) {
-                            renameParamsInCondition(condition.condition, suffix)
-                        }
-                    }
-                }
-                for (const where of existsQb.expressionMap.wheres) {
-                    if (typeof where.condition === 'string') {
-                        where.condition = where.condition.replace(
-                            /:([a-zA-Z0-9_]+)\b/g,
-                            (_, name) => `:${name}${suffix}`
-                        )
-                    } else {
-                        renameParamsInCondition(where.condition, suffix)
-                    }
+            for (const where of existsQb.expressionMap.wheres) {
+                if (typeof where.condition === 'string') {
+                    where.condition = renameParamsInString(where.condition)
+                } else {
+                    renameParamsInCondition(where.condition)
                 }
             }
-
-            return existsQb
         }
 
         // Determine the quantifier for this path (must be uniform across all sub-columns).
@@ -832,36 +1025,95 @@ export function addToManySubFilters<T>(
             // This is the only correct way to express "entity has ALL of these related values" —
             // a single EXISTS with AND conditions on the same column is always false on a single row.
 
-            // Build the base sub-query without the $and values (keeps OR-mode filters on other columns).
+            // $and comparator is incompatible with $none/$all quantifiers — the $and comparator
+            // already implies AND-mode (multiple correlated EXISTS), so combining it with a
+            // quantifier that changes the EXISTS semantics is a user error.
+            if (quantifier !== FilterQuantifier.ANY) {
+                throw new Error(
+                    `The $and comparator cannot be combined with the $${quantifier} quantifier on column ${path}. ` +
+                        `Use $any (the default) with $and, or use $${quantifier} without $and.`
+                )
+            }
+
+            // $and on multiple sub-columns produces a cartesian product of EXISTS subqueries,
+            // which has surprising semantics: each EXISTS asserts a separate row exists, not a
+            // single row matching all conditions. Disallow this to avoid silent incorrect results.
+            if (andSubColumns.length > 1) {
+                throw new Error(
+                    `The $and comparator cannot be used on multiple sub-columns of the same relation path ${path} simultaneously ` +
+                        `(found: ${andSubColumns.join(', ')}). Apply $and to a single sub-column at a time.`
+                )
+            }
+
+            // Build the base sub-query without the $and values (keeps OR-mode filters on other columns,
+            // and keeps any non-$and values on the $and sub-column itself).
+            //
+            // Note: OR-mode values on the $and sub-column (non-$and values mixed with $and values)
+            // are included in every EXISTS subquery as an additional filter. For example:
+            //   filter[toys.name]=$and:Ball&filter[toys.name]=$eq:Mouse
+            // produces EXISTS subqueries that each include `$eq:Mouse` as an additional condition.
+            // This means each EXISTS asserts: "a related row exists where name = 'Ball' AND name = 'Mouse'"
+            // (always false for a single row), which is likely not the intended behavior.
+            // Users should use only $and values or only OR-mode values on a given sub-column, not both.
             const baseSubQuery: PaginateQuery = {
                 ...subQuery,
                 filter: Object.fromEntries(
-                    Object.entries(subQuery.filter ?? {}).filter(([col]) => !andSubColumns.includes(col))
+                    Object.entries(subQuery.filter ?? {}).flatMap(([col, rawValues]) => {
+                        if (!andSubColumns.includes(col)) {
+                            return [[col, rawValues]]
+                        }
+                        // Reject mixing $and values with non-$and (OR-mode) values on the same sub-column.
+                        // A mixed filter would produce EXISTS subqueries with conditions like
+                        // `name = 'Ball' AND name = 'Mouse'` (always false on a single row),
+                        // which silently returns empty results rather than the user's intent.
+                        const values = Array.isArray(rawValues) ? rawValues : [rawValues]
+                        const orValues = values.filter((v) => !hasExplicitAndComparator(v))
+                        if (orValues.length > 0) {
+                            throw new Error(
+                                `Cannot mix $and values with non-$and values on sub-column "${col}" of relation "${path}". ` +
+                                    `Use either all $and or no $and on a given sub-column.`
+                            )
+                        }
+                        return []
+                    })
                 ),
             }
 
-            // For each $and value on each sub-column, emit a separate EXISTS.
-            // When there are multiple $and sub-columns, we emit the cartesian product — but in
-            // practice this is almost always a single sub-column (e.g. tag.id).
-            const andValueCombinations = andSubColumns.reduce<{ [col: string]: string }[]>(
-                (combinations, subCol) => {
-                    const values = andValuesBySubColumn[subCol]
-                    return combinations.flatMap((combo) => values.map((v) => ({ ...combo, [subCol]: v })))
-                },
-                [{}]
-            )
+            // For each $and value on the (single) sub-column, emit a separate EXISTS subquery.
+            // Multiple $and sub-columns are disallowed (throws above), so andSubColumns always
+            // has exactly one entry here.
+            const andSubCol = andSubColumns[0]
+            const andValues = andValuesBySubColumn[andSubCol]
 
-            for (const [comboIndex, combo] of andValueCombinations.entries()) {
+            // Validate that each $and value has an actual operand after the comparator.
+            // A bare `$and` (no colon separator) produces token.value = undefined, which
+            // would generate a malformed query. Require at least `$and:` with a value.
+            for (const v of andValues) {
+                const token = parseFilterToken(v)
+                if (!token || token.value === undefined) {
+                    throw new Error(
+                        `Invalid $and filter value "${v}" for column ${path}.${andSubCol}: ` +
+                            `$and must be followed by a value, e.g. "$and:Ball" or "$and:$eq:Ball".`
+                    )
+                }
+            }
+
+            if (andValues.length > maxAndValues) {
+                throw new Error(
+                    `Too many $and filter values for column ${path}.${andSubCol}: ${andValues.length} (max ${maxAndValues}). ` +
+                        `Reduce the number of $and values.`
+                )
+            }
+
+            for (const [comboIndex, v] of andValues.entries()) {
                 const singleValueSubQuery: PaginateQuery = {
                     ...baseSubQuery,
                     filter: {
                         ...baseSubQuery.filter,
-                        ...Object.fromEntries(Object.entries(combo).map(([col, v]) => [col, v])),
+                        [andSubCol]: v,
                     },
                 }
                 const existsQb = buildExistsQb(singleValueSubQuery, comboIndex)
-                // AND-mode always uses andWhereExists — $none/$all quantifiers are incompatible
-                // with $and comparator (mixing them is a user error caught by the quantifier check above).
                 qb.andWhereExists(existsQb)
             }
         } else {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -341,7 +341,9 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
 
 export function parseFilter<T>(
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    filterableColumns?: {
+        [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true
+    },
     qb?: SelectQueryBuilder<T>
 ): ColumnFilters {
     const filter: ColumnFilters = {}
@@ -605,7 +607,9 @@ export interface AddFilterOptions {
 export function addFilter<T>(
     qb: SelectQueryBuilder<T>,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    filterableColumns?: {
+        [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true
+    },
     opts: AddFilterOptions = {}
 ) {
     const mainMetadata = qb.expressionMap.mainAlias.metadata
@@ -693,7 +697,9 @@ export function addToManySubFilters<T>(
     qb: SelectQueryBuilder<T>,
     filter: ColumnFilters,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    filterableColumns?: {
+        [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true
+    },
     { maxAndValues = 20, validateAndComparator = true }: AddFilterOptions = {}
 ) {
     const dbType = qb.connection.options.type
@@ -897,7 +903,9 @@ export function addToManySubFilters<T>(
                     .map((jc) => {
                         const junctionCol = jc.databaseName
                         const relatedPk = jc.referencedColumn.databaseName
-                        return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
+                        return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(
+                            relatedPk
+                        )}`
                     })
                     .join(' AND ')
 
@@ -924,9 +932,7 @@ export function addToManySubFilters<T>(
                         fkAlias = relAlias(relationPath[0][0], 0)
                         pkAlias = mainQueryAlias
                     }
-                    existsQb.andWhere(
-                        `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
-                    )
+                    existsQb.andWhere(`${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`)
                 }
             }
         }
@@ -1134,7 +1140,9 @@ export function addToManySubFilters<T>(
 
 export function createSubFilter(
     query: PaginateQuery,
-    filterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
+    filterableColumns: {
+        [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true
+    },
     column: string
 ) {
     const subQuery = { filter: {} } as PaginateQuery
@@ -1143,7 +1151,9 @@ export function createSubFilter(
             subQuery.filter[getSubColumn(column, subColumn)] = filter
         }
     }
-    const subFilterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true } = {}
+    const subFilterableColumns: {
+        [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true
+    } = {}
     for (const [subColumn, filter] of Object.entries(filterableColumns)) {
         if (subColumn.startsWith(column + '.')) {
             subFilterableColumns[getSubColumn(column, subColumn)] = filter

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -296,7 +296,7 @@ function fixColumnFilterValue<T>(column: string, qb: SelectQueryBuilder<T>, isJs
 
 export function parseFilter<T>(
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier)[] | true },
+    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
     qb?: SelectQueryBuilder<T>
 ): ColumnFilters {
     const filter: ColumnFilters = {}
@@ -538,7 +538,7 @@ function findFirstToManyRelationship(
 export function addFilter<T>(
     qb: SelectQueryBuilder<T>,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier)[] | true }
+    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true }
 ) {
     const mainMetadata = qb.expressionMap.mainAlias.metadata
     const filter = parseFilter(query, filterableColumns, qb)
@@ -605,7 +605,7 @@ export function addToManySubFilters<T>(
     qb: SelectQueryBuilder<T>,
     filter: ColumnFilters,
     query: PaginateQuery,
-    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier)[] | true }
+    filterableColumns?: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true }
 ) {
     const dbType = qb.connection.options.type
     const quote = (column: string) => quoteColumn(column, ['mysql', 'mariadb'].includes(dbType))
@@ -627,128 +627,186 @@ export function addToManySubFilters<T>(
 
         // 1. Create the EXISTS subquery, starting from the toMany entity
         const existsMetadata = relation.inverseEntityMetadata
-        const existsQb = qb.connection.createQueryBuilder(existsMetadata.target as any, toManyAlias)
 
         if (existsMetadata.deleteDateColumn) {
             //existsQb.andWhere(`"${toManyAlias}"."${existsMetadata.deleteDateColumn.databaseName}" IS NULL`)
         }
 
-        // 2. Add the subfilters to the EXISTS subquery
+        // 2. Extract sub-filters for this path.
+        // If any sub-filter entry uses the $and comparator, we must emit one correlated EXISTS
+        // subquery per value — because a single EXISTS with AND conditions on the same column
+        // (e.g. WHERE tag.id = A AND tag.id = B) is always false on a single row.
+        // We split $and values into individual sub-queries and AND them on the outer query.
         const { subQuery, subFilterableColumns } = createSubFilter(query, filterableColumns, path)
-        const subJoins = addFilter(existsQb, subQuery, subFilterableColumns)
 
-        // 3. Add the sub relationship joins to the EXISTS subquery
-        const relationsSchema = mergeRelationSchema(createRelationSchema(Object.keys(subJoins)))
-        // Only inner join, no need to select anything
-        addRelationsFromSchema(existsQb, relationsSchema, {}, 'innerJoin')
-
-        // 4. Build the chain of joins that backtracks our toMany relationship to the root.
-
-        // We iterate from the second-to-last item (the immediate parent) back to the first item (root's child)
-        for (let i = relationPath.length - 1; i >= 0; i--) {
-            const [, meta] = relationPath[i]
-
-            // --- A: Skip Embedded Entities ---
-            if (meta.type === 'embedded') {
-                // Embedded entities exist within the current table (currentChildAlias).
-                // They do not require a JOIN, so we simply continue to the next item in the path.
-                continue
-            }
-
-            // --- B: Handle Table Relation (RelationMetadata) ---
-            // If we reach this point, 'meta' is a RelationMetadata object.
-            const parentMeta = meta as RelationMetadata
-
-            // Check if this is an intermediate or top-level relationship
-            if (i !== 0) {
-                // --- Intermediate Join (Joining two non-root tables within the subquery) ---
-
-                const parentAlias = `_rel_${relationPath[i - 1][0]}_${i - 1}`
-                const childAlias = `_rel_${relationPath[i][0]}_${i}`
-                const childRelationMetadata = parentMeta.inverseRelation
-
-                // Get the join columns from the inverse relation of the current metadata (e.g., inverse of 'pillows')
-                const joinCols = childRelationMetadata.joinColumns
-
-                // Construct the ON condition (handles composite keys)
-                const onConditions = joinCols
-                    .map((jc) => {
-                        const fk = jc.databaseName
-                        const pk = jc.referencedColumn.databaseName
-                        return `${quote(childAlias)}.${quote(fk)} = ${quote(parentAlias)}.${quote(pk)}`
-                    })
-                    .join(' AND ')
-
-                // Add the INNER JOIN to the subquery
-                existsQb.innerJoin(
-                    childRelationMetadata.inverseRelation.entityMetadata.target,
-                    parentAlias,
-                    onConditions
-                )
-            } else {
-                // Perform the final correlation WHERE clause to the main query alias
-                const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
-
-                if (parentMeta.isManyToMany) {
-                    // For ManyToMany, the FK columns live in the junction (join) table, not on the
-                    // related entity's table. We must JOIN the junction table into the EXISTS subquery
-                    // and correlate via it.
-                    const junctionMeta = joinMeta.junctionEntityMetadata
-                    const junctionAlias = `_junc_${relationPath[0][0]}_0`
-                    const relatedAlias = `_rel_${relationPath[0][0]}_0`
-
-                    // When accessed from the owning side:
-                    //   joinColumns        → junction → owning entity (mainQueryAlias)
-                    //   inverseJoinColumns → junction → inverse entity (relatedAlias)
-                    // When accessed from the inverse side, the roles are swapped.
-                    const toRelatedCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
-                    const toMainCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
-
-                    const junctionToRelatedConditions = toRelatedCols
-                        .map((jc) => {
-                            const junctionCol = jc.databaseName
-                            const relatedPk = jc.referencedColumn.databaseName
-                            return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(
-                                relatedPk
-                            )}`
-                        })
-                        .join(' AND ')
-
-                    const junctionTarget = junctionMeta.target ?? junctionMeta.tableName
-                    existsQb.innerJoin(junctionTarget, junctionAlias, junctionToRelatedConditions)
-
-                    // Correlate the junction table back to the main query entity.
-                    for (const joinColumn of toMainCols) {
-                        const junctionCol = joinColumn.databaseName
-                        const mainPk = joinColumn.referencedColumn.databaseName
-                        existsQb.andWhere(
-                            `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(mainQueryAlias)}.${quote(mainPk)}`
-                        )
-                    }
-                } else {
-                    for (const joinColumn of joinMeta.joinColumns) {
-                        // 1. Get the raw column names from the owning metadata:
-                        const fkColumn = joinColumn.databaseName
-                        const pkColumn = joinColumn.referencedColumn.databaseName
-
-                        // 2. Get the table aliases
-                        let fkAlias: string
-                        let pkAlias: string
-                        if (parentMeta.isOwning) {
-                            pkAlias = `_rel_${relationPath[0][0]}_0`
-                            fkAlias = mainQueryAlias
-                        } else {
-                            fkAlias = `_rel_${relationPath[0][0]}_0`
-                            pkAlias = mainQueryAlias
-                        }
-
-                        // Correlation
-                        existsQb.andWhere(`${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`)
-                    }
-                }
+        // Collect $and filter values per sub-column so we can split them out.
+        const andValuesBySubColumn: { [subCol: string]: string[] } = {}
+        for (const [subCol, rawValues] of Object.entries(subQuery.filter ?? {})) {
+            const values = Array.isArray(rawValues) ? rawValues : [rawValues]
+            const andValues = values.filter((v) => {
+                const token = parseFilterToken(v)
+                return token && token.comparator === FilterComparator.AND && token.quantifier === FilterQuantifier.ANY
+            })
+            if (andValues.length >= 1) {
+                andValuesBySubColumn[subCol] = andValues
             }
         }
 
+        // Determine how many EXISTS subqueries to emit for this path.
+        // If there are $and values on any sub-column, we need one EXISTS per value (for those columns).
+        // Other sub-columns (OR-mode) are included in every EXISTS subquery unchanged.
+        const andSubColumns = Object.keys(andValuesBySubColumn)
+
+        // Build a helper that constructs and correlates a single EXISTS subquery for this path.
+        // existsIndex must be unique per EXISTS emitted for this path to avoid alias collisions
+        // when multiple EXISTS subqueries are added to the same outer query (AND-mode).
+        const buildExistsQb = (extraSubQuery: PaginateQuery, existsIndex = 0) => {
+            const relAlias = (name: string, depth: number) => `_rel_${name}_${depth}_e${existsIndex}`
+            const juncAlias = (name: string, depth: number) => `_junc_${name}_${depth}_e${existsIndex}`
+            const leafAlias = relAlias(relationPath[relationPath.length - 1][0], relationPath.length - 1)
+            const existsQb = qb.connection.createQueryBuilder(existsMetadata.target as any, leafAlias)
+
+            const subJoins = addFilter(existsQb, extraSubQuery, subFilterableColumns)
+
+            // 3. Add the sub relationship joins to the EXISTS subquery
+            const relationsSchema = mergeRelationSchema(createRelationSchema(Object.keys(subJoins)))
+            addRelationsFromSchema(existsQb, relationsSchema, {}, 'innerJoin')
+
+            // 4. Build the chain of joins that backtracks our toMany relationship to the root.
+            for (let i = relationPath.length - 1; i >= 0; i--) {
+                const [, meta] = relationPath[i]
+
+                // --- A: Skip Embedded Entities ---
+                if (meta.type === 'embedded') {
+                    continue
+                }
+
+                // --- B: Handle Table Relation (RelationMetadata) ---
+                const parentMeta = meta as RelationMetadata
+
+                if (i !== 0) {
+                    // --- Intermediate Join ---
+                    const parentAlias = relAlias(relationPath[i - 1][0], i - 1)
+                    const childAlias = relAlias(relationPath[i][0], i)
+                    const childRelationMetadata = parentMeta.inverseRelation
+                    const joinCols = childRelationMetadata.joinColumns
+                    const onConditions = joinCols
+                        .map((jc) => {
+                            const fk = jc.databaseName
+                            const pk = jc.referencedColumn.databaseName
+                            return `${quote(childAlias)}.${quote(fk)} = ${quote(parentAlias)}.${quote(pk)}`
+                        })
+                        .join(' AND ')
+                    existsQb.innerJoin(
+                        childRelationMetadata.inverseRelation.entityMetadata.target,
+                        parentAlias,
+                        onConditions
+                    )
+                } else {
+                    // --- Root correlation ---
+                    const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
+
+                    if (parentMeta.isManyToMany) {
+                        // For ManyToMany, the FK columns live in the junction (join) table, not on the
+                        // related entity's table. We must JOIN the junction table into the EXISTS subquery
+                        // and correlate via it.
+                        const junctionMeta = joinMeta.junctionEntityMetadata
+                        const junctionAlias = juncAlias(relationPath[0][0], 0)
+                        const relatedAlias = relAlias(relationPath[0][0], 0)
+
+                        // When accessed from the owning side:
+                        //   joinColumns        → junction → owning entity (mainQueryAlias)
+                        //   inverseJoinColumns → junction → inverse entity (relatedAlias)
+                        // When accessed from the inverse side, the roles are swapped.
+                        const toRelatedCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
+                        const toMainCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
+
+                        const junctionToRelatedConditions = toRelatedCols
+                            .map((jc) => {
+                                const junctionCol = jc.databaseName
+                                const relatedPk = jc.referencedColumn.databaseName
+                                return `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(relatedAlias)}.${quote(relatedPk)}`
+                            })
+                            .join(' AND ')
+
+                        const junctionTarget = junctionMeta.target ?? junctionMeta.tableName
+                        existsQb.innerJoin(junctionTarget, junctionAlias, junctionToRelatedConditions)
+
+                        for (const joinColumn of toMainCols) {
+                            const junctionCol = joinColumn.databaseName
+                            const mainPk = joinColumn.referencedColumn.databaseName
+                            existsQb.andWhere(
+                                `${quote(junctionAlias)}.${quote(junctionCol)} = ${quote(mainQueryAlias)}.${quote(mainPk)}`
+                            )
+                        }
+                    } else {
+                        for (const joinColumn of joinMeta.joinColumns) {
+                            const fkColumn = joinColumn.databaseName
+                            const pkColumn = joinColumn.referencedColumn.databaseName
+                            let fkAlias: string
+                            let pkAlias: string
+                            if (parentMeta.isOwning) {
+                                pkAlias = relAlias(relationPath[0][0], 0)
+                                fkAlias = mainQueryAlias
+                            } else {
+                                fkAlias = relAlias(relationPath[0][0], 0)
+                                pkAlias = mainQueryAlias
+                            }
+                            existsQb.andWhere(
+                                `${quote(fkAlias)}.${quote(fkColumn)} = ${quote(pkAlias)}.${quote(pkColumn)}`
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Rename all parameters in the EXISTS subquery to include the existsIndex suffix,
+            // preventing parameter name collisions when multiple EXISTS subqueries are added
+            // to the same outer query (AND-mode emits one EXISTS per $and value).
+            if (existsIndex > 0) {
+                const suffix = `_e${existsIndex}`
+                const oldParams = { ...existsQb.expressionMap.parameters }
+                existsQb.expressionMap.parameters = {}
+                for (const [key, value] of Object.entries(oldParams)) {
+                    existsQb.expressionMap.parameters[key + suffix] = value
+                }
+                const renameParamsInCondition = (condition: any, suffix: string): void => {
+                    if (typeof condition === 'string') {
+                        return // handled at the where level
+                    }
+                    if (Array.isArray(condition)) {
+                        for (const item of condition) {
+                            renameParamsInCondition(item, suffix)
+                        }
+                        return
+                    }
+                    if (condition && typeof condition === 'object') {
+                        if (typeof condition.condition === 'string') {
+                            condition.condition = condition.condition.replace(
+                                /:([a-zA-Z0-9_]+)\b/g,
+                                (_, name) => `:${name}${suffix}`
+                            )
+                        } else if (condition.condition) {
+                            renameParamsInCondition(condition.condition, suffix)
+                        }
+                    }
+                }
+                for (const where of existsQb.expressionMap.wheres) {
+                    if (typeof where.condition === 'string') {
+                        where.condition = where.condition.replace(
+                            /:([a-zA-Z0-9_]+)\b/g,
+                            (_, name) => `:${name}${suffix}`
+                        )
+                    } else {
+                        renameParamsInCondition(where.condition, suffix)
+                    }
+                }
+            }
+
+            return existsQb
+        }
+
+        // Determine the quantifier for this path (must be uniform across all sub-columns).
         const quantifiers = Object.entries(filter)
             .filter(([key]) => key.startsWith(path))
             .flatMap(([, multiFilter]) => multiFilter.map((f) => f.quantifier))
@@ -763,20 +821,68 @@ export function addToManySubFilters<T>(
             }
         }
 
-        // 5. Add the EXISTS subquery to the main query
-        if (quantifier === FilterQuantifier.ANY) {
-            qb.andWhereExists(existsQb)
-        } else if (quantifier === FilterQuantifier.NONE) {
-            andWhereNoneExist(qb, existsQb)
-        } else if (quantifier === FilterQuantifier.ALL) {
-            andWhereAllExist(qb, existsQb)
+        if (andSubColumns.length > 0) {
+            // AND-mode: emit one EXISTS per $and value on each sub-column, ANDed on the outer query.
+            // OR-mode values on other sub-columns are included in every EXISTS subquery unchanged.
+            //
+            // Example: filter[tag.id]=$and:tagA&filter[tag.id]=$and:tagB produces:
+            //   AND EXISTS (SELECT 1 FROM tag JOIN junction ON ... WHERE tag.id = 'tagA' AND ...)
+            //   AND EXISTS (SELECT 1 FROM tag JOIN junction ON ... WHERE tag.id = 'tagB' AND ...)
+            //
+            // This is the only correct way to express "entity has ALL of these related values" —
+            // a single EXISTS with AND conditions on the same column is always false on a single row.
+
+            // Build the base sub-query without the $and values (keeps OR-mode filters on other columns).
+            const baseSubQuery: PaginateQuery = {
+                ...subQuery,
+                filter: Object.fromEntries(
+                    Object.entries(subQuery.filter ?? {}).filter(([col]) => !andSubColumns.includes(col))
+                ),
+            }
+
+            // For each $and value on each sub-column, emit a separate EXISTS.
+            // When there are multiple $and sub-columns, we emit the cartesian product — but in
+            // practice this is almost always a single sub-column (e.g. tag.id).
+            const andValueCombinations = andSubColumns.reduce<{ [col: string]: string }[]>(
+                (combinations, subCol) => {
+                    const values = andValuesBySubColumn[subCol]
+                    return combinations.flatMap((combo) => values.map((v) => ({ ...combo, [subCol]: v })))
+                },
+                [{}]
+            )
+
+            for (const [comboIndex, combo] of andValueCombinations.entries()) {
+                const singleValueSubQuery: PaginateQuery = {
+                    ...baseSubQuery,
+                    filter: {
+                        ...baseSubQuery.filter,
+                        ...Object.fromEntries(Object.entries(combo).map(([col, v]) => [col, v])),
+                    },
+                }
+                const existsQb = buildExistsQb(singleValueSubQuery, comboIndex)
+                // AND-mode always uses andWhereExists — $none/$all quantifiers are incompatible
+                // with $and comparator (mixing them is a user error caught by the quantifier check above).
+                qb.andWhereExists(existsQb)
+            }
+        } else {
+            // OR-mode (default): one shared EXISTS subquery for all values on this path.
+            const existsQb = buildExistsQb(subQuery)
+
+            // 5. Add the EXISTS subquery to the main query
+            if (quantifier === FilterQuantifier.ANY) {
+                qb.andWhereExists(existsQb)
+            } else if (quantifier === FilterQuantifier.NONE) {
+                andWhereNoneExist(qb, existsQb)
+            } else if (quantifier === FilterQuantifier.ALL) {
+                andWhereAllExist(qb, existsQb)
+            }
         }
     }
 }
 
 export function createSubFilter(
     query: PaginateQuery,
-    filterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier)[] | true },
+    filterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true },
     column: string
 ) {
     const subQuery = { filter: {} } as PaginateQuery
@@ -785,7 +891,7 @@ export function createSubFilter(
             subQuery.filter[getSubColumn(column, subColumn)] = filter
         }
     }
-    const subFilterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier)[] | true } = {}
+    const subFilterableColumns: { [column: string]: (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true } = {}
     for (const [subColumn, filter] of Object.entries(filterableColumns)) {
         if (subColumn.startsWith(column + '.')) {
             subFilterableColumns[getSubColumn(column, subColumn)] = filter

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -576,7 +576,13 @@ function findFirstToManyRelationship(
     columnName: string,
     metadata: EntityMetadata | EmbeddedMetadata
 ): { path: string[]; relation: RelationMetadata } | undefined {
-    const relationPath = getRelationPath(columnName, metadata)
+    let relationPath: ReturnType<typeof getRelationPath>
+    try {
+        relationPath = getRelationPath(columnName, metadata)
+    } catch (e) {
+        if (e instanceof RelationPathError) return undefined
+        throw e
+    }
     const relationSegments = columnName.split('.')
     const firstToMany = relationPath.findIndex(
         ([, relation]) => 'isOneToMany' in relation && (relation.isOneToMany || relation.isManyToMany)

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -5458,6 +5458,132 @@ describe('paginate', () => {
                 )
             })
 
+            describe('AND-mode filtering: entity must have ALL of the specified related values', () => {
+                // cats[0] (Milo) has toys: Ball, Mouse (created in beforeAll below)
+                // cats[1] has toy: String (from global setup)
+                // cats[2..6] have no toys
+                let andModeToys: CatToyEntity[]
+
+                beforeAll(async () => {
+                    andModeToys = await catToyRepo.save([
+                        catToyRepo.create({ name: 'Ball', cat: cats[0], size: { height: 5, width: 5, length: 5 } }),
+                        catToyRepo.create({ name: 'Mouse', cat: cats[0], size: { height: 3, width: 3, length: 8 } }),
+                    ])
+                })
+
+                afterAll(async () => {
+                    if (andModeToys?.length) {
+                        await catToyRepo.remove(andModeToys)
+                    }
+                })
+
+                it('should find cats that have a toy named Ball AND a toy named Mouse (OneToMany)', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': [`$and:Ball`, `$and:Mouse`],
+                        },
+                        path: '',
+                    }
+
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    // Only Milo (cats[0]) has both Ball and Mouse
+                    expect(result.data.length).toBe(1)
+                    expect(result.data[0].id).toBe(cats[0].id)
+                })
+
+                it('should return no cats when no cat has all specified toys (OneToMany)', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            // Ball belongs to Milo, String belongs to cats[1] — no cat has both
+                            'toys.name': [`$and:Ball`, `$and:String`],
+                        },
+                        path: '',
+                    }
+
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(0)
+                })
+
+                it('should find cats that have friends named Garfield AND Milo (ManyToMany owning side)', async () => {
+                    // cats[0] (Milo) has friends: cats[1..6] (Garfield, Whiskers, ...)
+                    // We need a cat that has at least two specific friends.
+                    // Only Milo has multiple friends, so filter for two of them.
+                    const garfield = cats[1]
+                    const whiskers = cats[2]
+
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'friends.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'friends.name': [`$and:${garfield.name}`, `$and:${whiskers.name}`],
+                        },
+                        path: '',
+                    }
+
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    // Only Milo has both Garfield and Whiskers as friends
+                    expect(result.data.length).toBe(1)
+                    expect(result.data[0].id).toBe(cats[0].id)
+                })
+
+                it('should return no cats when no cat has all specified friends (ManyToMany owning side)', async () => {
+                    // No cat has both Milo AND Garfield as friends simultaneously
+                    // (Milo's friends are cats[1..6], none of whom have friends themselves)
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'friends.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'friends.name': [`$and:${cats[0].name}`, `$and:${cats[1].name}`],
+                        },
+                        path: '',
+                    }
+
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(0)
+                })
+
+                it('should behave like OR-mode when only a single $and value is provided', async () => {
+                    // A single $and value should behave identically to $or (one EXISTS subquery, same result)
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': `$and:Ball`,
+                        },
+                        path: '',
+                    }
+
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    // Only Milo has Ball
+                    expect(result.data.length).toBe(1)
+                    expect(result.data[0].id).toBe(cats[0].id)
+                })
+            })
+
             describe('Advanced quantifier combinatorics', () => {
                 // None of these have been implemented yet, feel free to PR :innocent:
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -5584,6 +5584,197 @@ describe('paginate', () => {
                 })
             })
 
+            describe('AND-mode: edge cases and error conditions', () => {
+                let andModeToys2: CatToyEntity[]
+
+                beforeAll(async () => {
+                    // cats[0] (Milo) gets Ball and Mouse toys for two-path collision tests.
+                    // cats[1] (Garfield) gets a String toy.
+                    andModeToys2 = await catToyRepo.save([
+                        catToyRepo.create({ name: 'Ball', cat: cats[0], size: { height: 5, width: 5, length: 5 } }),
+                        catToyRepo.create({ name: 'Mouse', cat: cats[0], size: { height: 3, width: 3, length: 8 } }),
+                        catToyRepo.create({ name: 'String', cat: cats[1], size: { height: 1, width: 1, length: 30 } }),
+                    ])
+                })
+
+                afterAll(async () => {
+                    if (andModeToys2?.length) {
+                        await catToyRepo.remove(andModeToys2)
+                    }
+                })
+
+                it('should throw when mixing $and and non-$and values on the same sub-column', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            // $and:Ball mixed with plain $eq:Mouse on the same sub-column
+                            'toys.name': [`$and:Ball`, `$eq:Mouse`],
+                        },
+                        path: '',
+                    }
+                    await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                        /Cannot mix \$and values with non-\$and values/
+                    )
+                })
+
+                it('should throw when $and is used on a scalar (non-to-many) column', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            name: [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            name: [`$and:Milo`],
+                        },
+                        path: '',
+                    }
+                    await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                        /\$and comparator can only be used on to-many/
+                    )
+                })
+
+                it('should NOT throw when a literal value containing $and is used on a scalar column without $and allowed', async () => {
+                    // A user searching for the literal string "$and" as a value (not as a comparator)
+                    // should not trigger the scalar-column validation.
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            name: [FilterOperator.EQ],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            // $eq:$and — operator is $eq, value is the literal string "$and"
+                            name: [`$eq:$and`],
+                        },
+                        path: '',
+                    }
+                    // Should not throw — no cat has name "$and", so result is empty
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(0)
+                })
+
+                it('should filter across two independent to-many paths without alias/parameter collisions', async () => {
+                    // Filter on both toys.name (OneToMany) and friends.name (ManyToMany) simultaneously.
+                    // cats[0] (Milo) has toys [Ball, Mouse] and friends [cats[1..6]].
+                    // We filter: toys.name=$and:Ball AND friends.name=$and:Garfield
+                    // Only Milo satisfies both.
+                    const garfield = cats[1]
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                            'friends.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': [`$and:Ball`],
+                            'friends.name': [`$and:${garfield.name}`],
+                        },
+                        path: '',
+                    }
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(1)
+                    expect(result.data[0].id).toBe(cats[0].id)
+                })
+
+                it('should filter across two independent to-many paths with multiple $and values each', async () => {
+                    // Milo has toys [Ball, Mouse] and friends [cats[1], cats[2], ...].
+                    // Filter: toys.name=$and:Ball&toys.name=$and:Mouse AND friends.name=$and:Garfield&friends.name=$and:Whiskers
+                    const garfield = cats[1]
+                    const whiskers = cats[2]
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                            'friends.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': [`$and:Ball`, `$and:Mouse`],
+                            'friends.name': [`$and:${garfield.name}`, `$and:${whiskers.name}`],
+                        },
+                        path: '',
+                    }
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(1)
+                    expect(result.data[0].id).toBe(cats[0].id)
+                })
+
+                it('should return no results when two-path filter has no matching entity', async () => {
+                    // No cat has both a toy named "String" AND a friend named Garfield.
+                    // cats[1] (Garfield) has String toy but no friends.
+                    // cats[0] (Milo) has friends but no String toy.
+                    const garfield = cats[1]
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                            'friends.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': [`$and:String`],
+                            'friends.name': [`$and:${garfield.name}`],
+                        },
+                        path: '',
+                    }
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(0)
+                })
+            })
+
+            describe('AND-mode: ManyToMany inverse-side filtering', () => {
+                it('should find cats that are a friend-of cats with specific names (inverse ManyToMany)', async () => {
+                    // cats[0] (Milo) has friends: cats[1..6].
+                    // From the inverse side: cats[1..6] are each "friendOf" Milo.
+                    // Filter friendOf.name=$and:Milo — should return cats[1..6] (all who have Milo as a friend).
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'friendOf.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'friendOf.name': [`$and:${cats[0].name}`],
+                        },
+                        path: '',
+                    }
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    // cats[1..6] are all friends of Milo (cats[0])
+                    expect(result.data.length).toBe(6)
+                    expect(result.data.map((c) => c.id)).not.toContain(cats[0].id)
+                })
+
+                it('should return no cats when filtering inverse ManyToMany with a non-existent friend name', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'friendOf.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'friendOf.name': [`$and:NonExistentCat`],
+                        },
+                        path: '',
+                    }
+                    const result = await paginate<CatEntity>(query, catRepo, config)
+                    expect(result.data.length).toBe(0)
+                })
+            })
+
             describe('Advanced quantifier combinatorics', () => {
                 // None of these have been implemented yet, feel free to PR :innocent:
 
@@ -5622,6 +5813,26 @@ describe('paginate', () => {
                     }
 
                     await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toBeDefined()
+                })
+            })
+
+            describe('$and value validation', () => {
+                it('should throw when a bare $and (no value) is used', async () => {
+                    const config: PaginateConfig<CatEntity> = {
+                        sortableColumns: ['id'],
+                        filterableColumns: {
+                            'toys.name': [FilterOperator.EQ, FilterComparator.AND],
+                        },
+                    }
+                    const query: PaginateQuery = {
+                        filter: {
+                            'toys.name': [`$and`],
+                        },
+                        path: '',
+                    }
+                    await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                        /Invalid \$and filter value/
+                    )
                 })
             })
         })

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -12,7 +12,7 @@ import {
 } from 'typeorm'
 import { WherePredicateOperator } from 'typeorm/query-builder/WhereClause'
 import { PaginateQuery } from './decorator'
-import { addFilter, FilterOperator, FilterQuantifier, FilterSuffix } from './filter'
+import { addFilter, FilterComparator, FilterOperator, FilterQuantifier, FilterSuffix } from './filter'
 import {
     checkIsEmbedded,
     checkIsRelation,
@@ -46,7 +46,7 @@ import globalConfig from './global-config'
 
 const logger: Logger = new Logger('nestjs-paginate')
 
-export { FilterOperator, FilterSuffix }
+export { FilterComparator, FilterOperator, FilterSuffix }
 
 export class Paginated<T> {
     data: T[]
@@ -92,7 +92,7 @@ export interface PaginateConfig<T> {
     defaultSortBy?: SortBy<T>
     defaultLimit?: number
     where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
-    filterableColumns?: Partial<MappedColumns<T, (FilterOperator | FilterSuffix | FilterQuantifier)[] | true>>
+    filterableColumns?: Partial<MappedColumns<T, (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true>>
     loadEagerRelations?: boolean
     withDeleted?: boolean
     allowWithDeletedInQuery?: boolean

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -12,7 +12,7 @@ import {
 } from 'typeorm'
 import { WherePredicateOperator } from 'typeorm/query-builder/WhereClause'
 import { PaginateQuery } from './decorator'
-import { addFilter, FilterComparator, FilterOperator, FilterQuantifier, FilterSuffix } from './filter'
+import { addFilter, AddFilterOptions, FilterComparator, FilterOperator, FilterQuantifier, FilterSuffix } from './filter'
 import {
     checkIsEmbedded,
     checkIsRelation,
@@ -46,7 +46,7 @@ import globalConfig from './global-config'
 
 const logger: Logger = new Logger('nestjs-paginate')
 
-export { FilterComparator, FilterOperator, FilterSuffix }
+export { AddFilterOptions, FilterComparator, FilterOperator, FilterSuffix }
 
 export class Paginated<T> {
     data: T[]
@@ -93,6 +93,7 @@ export interface PaginateConfig<T> {
     defaultLimit?: number
     where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
     filterableColumns?: Partial<MappedColumns<T, (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true>>
+    maxAndValues?: number
     loadEagerRelations?: boolean
     withDeleted?: boolean
     allowWithDeletedInQuery?: boolean
@@ -663,7 +664,7 @@ export async function paginate<T extends ObjectLiteral>(
 
     let filterJoinMethods = {}
     if (query.filter) {
-        filterJoinMethods = addFilter(queryBuilder, query, config.filterableColumns)
+        filterJoinMethods = addFilter(queryBuilder, query, config.filterableColumns, { maxAndValues: config.maxAndValues })
     }
     const joinMethods = { ...filterJoinMethods, ...config.joinMethods }
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -92,7 +92,9 @@ export interface PaginateConfig<T> {
     defaultSortBy?: SortBy<T>
     defaultLimit?: number
     where?: FindOptionsWhere<T> | FindOptionsWhere<T>[]
-    filterableColumns?: Partial<MappedColumns<T, (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true>>
+    filterableColumns?: Partial<
+        MappedColumns<T, (FilterOperator | FilterSuffix | FilterQuantifier | FilterComparator)[] | true>
+    >
     maxAndValues?: number
     loadEagerRelations?: boolean
     withDeleted?: boolean
@@ -664,7 +666,9 @@ export async function paginate<T extends ObjectLiteral>(
 
     let filterJoinMethods = {}
     if (query.filter) {
-        filterJoinMethods = addFilter(queryBuilder, query, config.filterableColumns, { maxAndValues: config.maxAndValues })
+        filterJoinMethods = addFilter(queryBuilder, query, config.filterableColumns, {
+            maxAndValues: config.maxAndValues,
+        })
     }
     const joinMethods = { ...filterJoinMethods, ...config.joinMethods }
 


### PR DESCRIPTION
Adds support for $and comparator on to-many filtered columns, allowing callers to express 'entity must have ALL of these related values' semantics.

Key changes:
- addToManySubFilters: detect $and comparator values on sub-columns and emit one correlated EXISTS subquery per value (ANDed on outer query), instead of a single shared EXISTS where AND conditions on the same column would always be false on a single row
- buildExistsQb: accepts existsIndex to make aliases unique per EXISTS (prevents TypeORM alias deduplication collapsing multiple subqueries)
- Parameter renaming: recursively renames :paramName references in WHERE conditions of non-first EXISTS subqueries to avoid parameter collision when TypeORM merges subquery parameters into the outer query
- FilterComparator exported from paginate.ts for consumer use
- ManyToMany junction table support added (cherry-pick of commit 66404d8)
- 5 new tests covering OneToMany AND-mode, ManyToMany AND-mode, negative cases, and single-value $and (should behave like OR-mode)