### PR TITLE
feat: polymorphic sort across columns via COALESCE (~ syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,44 @@ const config: PaginateConfig<CatEntity> = {
 const result = await paginate<CatEntity>(query, catRepo, config)
 ```
 
+## Polymorphic sorting
+
+Sometimes the value you want to sort on can come from one of several columns — for
+example a record that links to one of two relations and you want to order by
+whichever one is set. Join columns into a single sort term with `~` and the rows
+are ordered by the `COALESCE` of those columns (the first non-`null` value per row).
+
+### Endpoint
+
+```
+http://localhost:3000/cats?sortBy=bestFriend.age~nemesis.age:DESC
+```
+
+This orders by `COALESCE(bestFriend.age, nemesis.age)` — a cat's best friend's age,
+or its nemesis's age when it has no best friend.
+
+### Code
+
+```typescript
+const config: PaginateConfig<CatEntity> = {
+  // Every column used in a group must be listed in sortableColumns.
+  sortableColumns: ['id', 'bestFriend.age', 'nemesis.age'],
+  relations: ['bestFriend', 'nemesis'],
+}
+```
+
+Notes and limitations:
+
+- The grouped columns must be **type-compatible** (e.g. all numbers, or all dates).
+  Mixing incompatible types lets the database raise its own error; types are not
+  coerced for you.
+- A group is only applied when **every** column in it is listed in `sortableColumns`;
+  otherwise the term is ignored.
+- Only **plain** and **relation** columns are supported in a group. Embedded, virtual,
+  and JSONB-path columns are rejected.
+- Polymorphic groups are **not supported with cursor pagination** (the COALESCE value
+  cannot be encoded into a cursor) and will throw.
+
 ## Filters
 
 Filter operators must be whitelisted per column in `PaginateConfig`.

--- a/src/__tests__/cat.entity.ts
+++ b/src/__tests__/cat.entity.ts
@@ -7,6 +7,7 @@ import {
     JoinColumn,
     JoinTable,
     ManyToMany,
+    ManyToOne,
     OneToMany,
     OneToOne,
     PrimaryGeneratedColumn,
@@ -66,6 +67,14 @@ export class CatEntity {
 
     @ManyToMany(() => CatEntity, (cat) => cat.friends)
     friendOf: CatEntity[]
+
+    // Two parallel to-one relations used to exercise polymorphic (~) sorting,
+    // e.g. sortBy=bestFriend.age~nemesis.age -> COALESCE(bestFriend.age, nemesis.age).
+    @ManyToOne(() => CatEntity, { nullable: true })
+    bestFriend: CatEntity | null
+
+    @ManyToOne(() => CatEntity, { nullable: true })
+    nemesis: CatEntity | null
 
     @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
     weightChange: number | null

--- a/src/decorator.spec.ts
+++ b/src/decorator.spec.ts
@@ -168,6 +168,19 @@ describe('Decorator', () => {
         })
     })
 
+    it('should parse polymorphic (~) sort groups into column arrays', () => {
+        const context = expressContextFactory({
+            sortBy: ['bestFriend.age~nemesis.age:ASC', 'name:DESC'],
+        })
+
+        const result: PaginateQuery = decoratorfactory(null, context)
+
+        expect(result.sortBy).toStrictEqual([
+            [['bestFriend.age', 'nemesis.age'], 'ASC'],
+            ['name', 'DESC'],
+        ])
+    })
+
     it('should handle fastify defined query fields', () => {
         const context = fastifyContextFactory({
             page: '1',

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -15,7 +15,7 @@ function isExpressRequest(request: unknown): request is ExpressRequest {
 export interface PaginateQuery {
     page?: number
     limit?: number
-    sortBy?: [string, string][]
+    sortBy?: [string | string[], string][]
     searchBy?: string[]
     search?: string
     filter?: { [column: string]: string | string[] }
@@ -96,7 +96,9 @@ export const Paginate = createParamDecorator((_data: unknown, ctx: ExecutionCont
     }
 
     const searchBy = parseParam<string>(query.searchBy, singleSplit)
-    const sortBy = parseParam<[string, string]>(query.sortBy, multipleSplit)
+    const sortBy = parseParam<[string, string]>(query.sortBy, multipleSplit)?.map(
+        ([column, order]) => [column.includes('~') ? column.split('~') : column, order] as [string | string[], string]
+    )
     const select = parseParam<string>(query.select, multipleAndCommaSplit)
 
     const filter = mapKeys(

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -85,7 +85,7 @@ export type RelationColumn<T> = Extract<
     }[Column<T>]
 >
 
-export type Order<T> = [Column<T>, 'ASC' | 'DESC']
+export type Order<T> = [Column<T> | Column<T>[], 'ASC' | 'DESC']
 export type SortBy<T> = Order<T>[]
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -183,6 +183,20 @@ describe('paginate', () => {
             }),
         ])
 
+        // Link cats via two parallel to-one relations for polymorphic (~) sort tests.
+        // Saved as fresh objects so the shared `cats` fixture is not mutated. Some cats
+        // get a bestFriend, others only a nemesis, so COALESCE(bestFriend.age, nemesis.age)
+        // exercises the fallback from the first source to the second.
+        await catRepo.save([
+            catRepo.create({ id: cats[0].id, bestFriend: cats[2] }), // Milo  -> 4 (Shadow)
+            catRepo.create({ id: cats[1].id, nemesis: cats[0] }), //    Garfield -> 6 (Milo)
+            catRepo.create({ id: cats[2].id, bestFriend: cats[3] }), // Shadow -> 3 (George)
+            catRepo.create({ id: cats[3].id, nemesis: cats[5] }), //    George -> 0 (Baby)
+            catRepo.create({ id: cats[4].id, bestFriend: cats[1] }), // Leche  -> 5 (Garfield)
+            catRepo.create({ id: cats[5].id, nemesis: cats[2] }), //    Baby   -> 4 (Shadow)
+            catRepo.create({ id: cats[6].id, bestFriend: cats[0] }), // Adam   -> 6 (Milo)
+        ])
+
         toyShopsAddresses = await toyShopAddressRepository.save([
             toyShopAddressRepository.create({ address: '123 Main St' }),
         ])
@@ -827,6 +841,97 @@ describe('paginate', () => {
             ['name', 'ASC'],
         ])
         expect(result.data).toStrictEqual(sortedCats)
+    })
+
+    describe('polymorphic sort (~)', () => {
+        // Mirrors SQL COALESCE(bestFriend.age, nemesis.age) for the links set up in beforeAll.
+        const coalescedAge = (cat: CatEntity): number | null => cat.bestFriend?.age ?? cat.nemesis?.age ?? null
+
+        it('should sort by a polymorphic column group using COALESCE (ASC)', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', 'bestFriend.age', 'nemesis.age'],
+                relations: ['bestFriend', 'nemesis'],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [[['bestFriend.age', 'nemesis.age'], 'ASC']],
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            expect(result.meta.sortBy).toStrictEqual([[['bestFriend.age', 'nemesis.age'], 'ASC']])
+
+            const values = result.data.map(coalescedAge)
+            // Every cat resolves to a non-null age through one of the two relations.
+            expect(values.every((v) => typeof v === 'number')).toBe(true)
+            // The COALESCE result is ordered ascending.
+            expect(values).toStrictEqual([...(values as number[])].sort((a, b) => a - b))
+            // The fallback actually fires: some rows resolve via nemesis (no bestFriend).
+            expect(result.data.some((cat) => !cat.bestFriend && !!cat.nemesis)).toBe(true)
+        })
+
+        it('should sort by a polymorphic column group using COALESCE (DESC)', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', 'bestFriend.age', 'nemesis.age'],
+                relations: ['bestFriend', 'nemesis'],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [[['bestFriend.age', 'nemesis.age'], 'DESC']],
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            const values = result.data.map(coalescedAge)
+            expect(values).toStrictEqual([...(values as number[])].sort((a, b) => b - a))
+        })
+
+        it('should ignore a polymorphic group when one of its columns is not sortable', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', 'bestFriend.age'], // nemesis.age intentionally omitted
+                relations: ['bestFriend', 'nemesis'],
+                defaultSortBy: [['id', 'ASC']],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [[['bestFriend.age', 'nemesis.age'], 'ASC']],
+            }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            // The group is dropped during validation, so the default sort applies.
+            expect(result.meta.sortBy).toStrictEqual([['id', 'ASC']])
+        })
+
+        it('should reject a polymorphic group with cursor pagination', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', 'bestFriend.age', 'nemesis.age'],
+                relations: ['bestFriend', 'nemesis'],
+                paginationType: PaginationType.CURSOR,
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [[['bestFriend.age', 'nemesis.age'], 'ASC']],
+            }
+
+            await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                'Polymorphic sort groups (using "~") are not supported with cursor pagination.'
+            )
+        })
+
+        it('should reject embedded columns inside a polymorphic group', async () => {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', 'size.height', 'age'],
+            }
+            const query: PaginateQuery = {
+                path: '',
+                sortBy: [[['size.height', 'age'], 'ASC']],
+            }
+
+            await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                'Polymorphic sort groups (using "~") support only plain and relation columns'
+            )
+        })
     })
 
     it('should return result based on search term', async () => {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -449,7 +449,17 @@ export async function paginate<T extends ObjectLiteral>(
 
     if (query.sortBy) {
         for (const order of query.sortBy) {
-            if (isEntityKey(config.sortableColumns, order[0]) && ['ASC', 'DESC'].includes(order[1])) {
+            const [column, direction] = order
+            if (!['ASC', 'DESC'].includes(direction)) {
+                continue
+            }
+            // A polymorphic group (e.g. `colA~colB`) is valid only when every
+            // column in the group is sortable.
+            if (Array.isArray(column)) {
+                if (column.length > 0 && column.every((c) => isEntityKey(config.sortableColumns, c))) {
+                    sortBy.push(order as Order<T>)
+                }
+            } else if (isEntityKey(config.sortableColumns, column)) {
                 sortBy.push(order as Order<T>)
             }
         }
@@ -457,6 +467,13 @@ export async function paginate<T extends ObjectLiteral>(
 
     if (!sortBy.length) {
         sortBy.push(...(config.defaultSortBy || [[config.sortableColumns[0], 'ASC']]))
+    }
+
+    // Polymorphic sort groups rely on a COALESCE expression in the SELECT/ORDER BY,
+    // which cannot be encoded into a cursor token. Reject the combination explicitly
+    // rather than producing silently-wrong cursors.
+    if (config.paginationType === PaginationType.CURSOR && sortBy.some(([column]) => Array.isArray(column))) {
+        logAndThrowException('Polymorphic sort groups (using "~") are not supported with cursor pagination.')
     }
 
     const searchBy: Column<T>[] = []
@@ -591,7 +608,9 @@ export async function paginate<T extends ObjectLiteral>(
             }
 
             const cursorExpressions = sortBy.map(([column, direction]) => {
-                const columnProperties = getPropertiesByColumnName(column)
+                // Polymorphic sort groups are rejected for cursor pagination above,
+                // so every column here is a plain string.
+                const columnProperties = getPropertiesByColumnName(column as string)
                 const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(
                     queryBuilder,
                     columnProperties
@@ -700,7 +719,61 @@ export async function paginate<T extends ObjectLiteral>(
         }
 
         for (const order of sortBy) {
-            const columnProperties = getPropertiesByColumnName(order[0])
+            const [sortColumn, sortDirection] = order
+
+            // Polymorphic sort: `colA~colB` sorts by COALESCE(colA, colB) — the first
+            // non-null value per row. The grouped columns must be type-compatible.
+            if (Array.isArray(sortColumn)) {
+                const escape = (identifier: string) => queryBuilder.connection.driver.escape(identifier)
+                const coalesceExpr = `COALESCE(${sortColumn
+                    .map((column) => {
+                        const props = getPropertiesByColumnName(column)
+                        const { isVirtualProperty } = extractVirtualProperty(queryBuilder, props)
+                        const isEmbedded = checkIsEmbedded(queryBuilder, props.propertyPath)
+                        if (isVirtualProperty || isEmbedded || resolveJsonbPath(queryBuilder, props.column).isJsonb) {
+                            logAndThrowException(
+                                `Polymorphic sort groups (using "~") support only plain and relation columns, not "${column}".`
+                            )
+                        }
+                        const isRelation = checkIsRelation(queryBuilder, props.propertyPath)
+                        // For plain and relation columns fixColumnAlias returns `<alias>.<column>`
+                        // with a single dot. Escape each identifier so camel-cased columns work
+                        // on case-folding drivers (e.g. Postgres), since this raw expression is
+                        // added to the SELECT list and is not escaped by the query builder.
+                        const ref = fixColumnAlias(
+                            props,
+                            queryBuilder.alias,
+                            isRelation,
+                            false,
+                            false,
+                            undefined,
+                            queryBuilder
+                        )
+                        const separator = ref.indexOf('.')
+                        return `${escape(ref.slice(0, separator))}.${escape(ref.slice(separator + 1))}`
+                    })
+                    .join(', ')})`
+                const polymorphAlias = `_polymorph_${sortColumn.join('_').replace(/[^a-zA-Z0-9]/g, '_')}`.toLowerCase()
+                queryBuilder.addSelect(coalesceExpr, polymorphAlias)
+
+                if (isMySqlOrMariaDb) {
+                    if (nullSort) {
+                        const selectionAliasName = `${polymorphAlias}IsNull`
+                        queryBuilder.addSelect(`${coalesceExpr} ${nullSort}`, selectionAliasName)
+                        queryBuilder.addOrderBy(selectionAliasName)
+                    }
+                    queryBuilder.addOrderBy(polymorphAlias, sortDirection)
+                } else {
+                    queryBuilder.addOrderBy(
+                        polymorphAlias,
+                        sortDirection,
+                        nullSort as 'NULLS FIRST' | 'NULLS LAST' | undefined
+                    )
+                }
+                continue
+            }
+
+            const columnProperties = getPropertiesByColumnName(sortColumn)
             const { isVirtualProperty, query: virtualQuery } = extractVirtualProperty(queryBuilder, columnProperties)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
             const isEmbedded = checkIsEmbedded(queryBuilder, columnProperties.propertyPath)


### PR DESCRIPTION
I was stupid enough to think polymorphic relationships were a good idea, and ran into a limitation when trying to sort using `nestjs-paginate`. I added this extension syntax that lets you COALESCE columns to sort by: `sortBy=friend.age~enemy.age:DESC` for entities that have a polymorphic relationship and need to sort across it. Expect similar shenanigans for polymorphic filtering soon ;p

---

### What it does

Group multiple columns in one `sortBy` term with `~`; rows are ordered by `COALESCE(...)` of those columns — the first non-`null` value per row:

```
sortBy=bestFriend.age~nemesis.age:DESC
→ ORDER BY COALESCE(bestFriend.age, nemesis.age) DESC
```

### How

- `sortBy` / `Order<T>` widened to accept a column group (`[string | string[], direction]`); the `Paginate` decorator splits a term on `~`. Existing single-column usage is unchanged.
- A group is only honored when **every** column in it is listed in `sortableColumns`, otherwise the term is dropped (same behavior as an unknown column today).
- The ORDER BY builds a `COALESCE` of the grouped columns and selects it under a `_polymorph_…` alias (so it survives `SELECT DISTINCT`), with per-driver identifier escaping via `driver.escape` so camelCase columns work on Postgres.
- The existing single-column ORDER BY path (virtual columns, JSONB, vc-sort subqueries) is left untouched.

### Deliberate limitations (easy to lift if you'd prefer)

- **Cursor pagination**: groups are rejected — the COALESCE value can't be encoded into a cursor.
- **Column kinds**: only plain and relation columns in a group; embedded / virtual / JSONB-path columns throw a clear error.
- **Types**: grouped columns must be type-compatible; no coercion (the DB raises its own error otherwise).

### Tests & docs

- New specs: ASC/DESC group sort across two relations, group-dropped-when-not-sortable, cursor rejection, embedded rejection, and a decorator parsing test. Added `bestFriend` / `nemesis` self-relations to the test `CatEntity` to model the polymorphic case (seeded without mutating the shared `cats` fixture).
- CI exercises the suite across SQLite, Postgres, and MariaDB.
- README: new "Polymorphic sorting" section.

Happy to adjust naming, scope, or the `~` operator if you'd prefer something else.