### PR TITLE
feat: add opt-in optimizedCount to prune hydration joins from the count query

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,22 @@ const paginateConfig: PaginateConfig<CatEntity> {
    * ```
    */
   buildCountQuery: (qb: SelectQueryBuilder<T>) => SelectQueryBuilder<any>,
+
+  /**
+   * Required: false
+   * Type: boolean
+   * Default: false
+   * Description: Build the COUNT query from a pruned clone of the main query
+   * instead of counting over the fully-joined statement. LEFT JOINs that the
+   * WHERE clause does not reference are removed before counting (INNER JOINs
+   * and the parent chains of referenced joins are kept), so configs that join
+   * many relations purely for hydration no longer pay for them in the count.
+   *
+   * The page data query is unaffected. Ignored when buildCountQuery is set;
+   * the pruning helper is exported as `buildOptimizedCountQuery` so it can be
+   * composed inside a custom buildCountQuery as well.
+   */
+  optimizedCount: true,
 }
 ````
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -3,6 +3,7 @@ import {
     FindOperator,
     FindOptionsRelationByString,
     FindOptionsRelations,
+    ObjectLiteral,
     Repository,
     SelectQueryBuilder,
 } from 'typeorm'
@@ -519,4 +520,58 @@ export function andWhereAllExist(
     // so it should be safe to replace the first WHERE with WHERE NOT (...) and get a correct query.
     const existsWhereNot = query.replace('WHERE', 'WHERE NOT (') + ')'
     return qb.andWhere(`NOT ${existsWhereNot}`, params)
+}
+
+/**
+ * Strips the parts of a fully-built paginate query that do not affect how many root
+ * entities match, so the count query stays cheap even when many relations are joined
+ * for hydration.
+ *
+ * Pruning rules:
+ * - INNER joins are always kept: they restrict the result set even when unreferenced.
+ * - LEFT joins are kept only when the WHERE clause references their alias.
+ * - Parent joins of any kept join are kept, so nested relation chains stay intact.
+ * - ORDER BY is cleared, since ordering does not change the count.
+ *
+ * Used by `paginate` when `PaginateConfig.optimizedCount` is enabled. It can also be
+ * composed inside a custom `PaginateConfig.buildCountQuery`.
+ *
+ * @param {SelectQueryBuilder<T>} qb A clone of the fully-built query builder.
+ * @return {SelectQueryBuilder<T>} The same builder with count-irrelevant joins removed.
+ */
+export function buildOptimizedCountQuery<T extends ObjectLiteral>(qb: SelectQueryBuilder<T>): SelectQueryBuilder<T> {
+    qb.orderBy()
+    // Protected TypeORM API that renders only the WHERE clause. Slicing getQuery() at
+    // its first WHERE instead would false-match subqueries rendered into the SELECT
+    // clause, such as virtual columns.
+    const whereSql: string = qb['createWhereExpression']()
+
+    const joins = qb.expressionMap.joinAttributes
+    const rootAlias = qb.expressionMap.mainAlias?.name
+    const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const isReferenced = (alias: string) =>
+        whereSql.includes(`"${alias}".`) || new RegExp(`(?<![\\w"])${escapeRegExp(alias)}\\.`).test(whereSql)
+
+    const kept = new Set<string>()
+    for (const join of joins) {
+        if (join.direction === 'INNER' || isReferenced(join.alias.name)) {
+            kept.add(join.alias.name)
+        }
+    }
+
+    let added = true
+    while (added) {
+        added = false
+        for (const join of joins) {
+            if (!kept.has(join.alias.name)) continue
+            const parent = join.parentAlias
+            if (parent && parent !== rootAlias && !kept.has(parent)) {
+                kept.add(parent)
+                added = true
+            }
+        }
+    }
+
+    qb.expressionMap.joinAttributes = joins.filter((join) => kept.has(join.alias.name))
+    return qb
 }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -22,7 +22,14 @@ import {
     OperatorSymbolToFunction,
     parseFilterToken,
 } from './filter'
-import { paginate, PaginateConfig, Paginated, PaginationLimit, PaginationType } from './paginate'
+import {
+    buildOptimizedCountQuery,
+    paginate,
+    PaginateConfig,
+    Paginated,
+    PaginationLimit,
+    PaginationType,
+} from './paginate'
 import globalConfig, { updateGlobalConfig } from './global-config'
 
 // Disable debug logs during tests
@@ -3294,6 +3301,71 @@ describe('paginate', () => {
 
         expect(fakeQB.getCount).toHaveBeenCalledTimes(1)
         expect(page.meta.totalItems).toBe(42)
+    })
+
+    it('should return the same results with optimizedCount as the default count', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            relations: ['toys', 'home'],
+            filterableColumns: { color: [FilterOperator.EQ] },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: { color: 'white' },
+        }
+
+        const defaultResult = await paginate<CatEntity>(query, catRepo, config)
+        const optimizedResult = await paginate<CatEntity>(query, catRepo, { ...config, optimizedCount: true })
+
+        expect(defaultResult.meta.totalItems).toBeGreaterThan(0)
+        expect(optimizedResult.meta.totalItems).toBe(defaultResult.meta.totalItems)
+        expect(optimizedResult.data).toStrictEqual(defaultResult.data)
+    })
+
+    it('should return the same results with optimizedCount when filtering through a relation', async () => {
+        const config: PaginateConfig<CatToyEntity> = {
+            sortableColumns: ['id'],
+            relations: ['cat', 'shop'],
+            filterableColumns: { 'cat.color': [FilterOperator.EQ] },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: { 'cat.color': 'ginger' },
+        }
+
+        const defaultResult = await paginate<CatToyEntity>(query, catToyRepo, config)
+        const optimizedResult = await paginate<CatToyEntity>(query, catToyRepo, { ...config, optimizedCount: true })
+
+        expect(defaultResult.meta.totalItems).toBeGreaterThan(0)
+        expect(optimizedResult.meta.totalItems).toBe(defaultResult.meta.totalItems)
+        expect(optimizedResult.data).toStrictEqual(defaultResult.data)
+    })
+
+    it('should prune joins the where clause does not reference from the count query', async () => {
+        const queryBuilder = catRepo
+            .createQueryBuilder('cats')
+            .leftJoinAndSelect('cats.toys', 'toys')
+            .leftJoinAndSelect('cats.home', 'home')
+            .where('cats.color = :color', { color: 'white' })
+
+        const prunedQueryBuilder = buildOptimizedCountQuery(queryBuilder.clone())
+
+        expect(prunedQueryBuilder.expressionMap.joinAttributes).toHaveLength(0)
+        expect(await prunedQueryBuilder.getCount()).toBe(await queryBuilder.getCount())
+    })
+
+    it('should keep joins referenced by the where clause in the count query', async () => {
+        const queryBuilder = catRepo
+            .createQueryBuilder('cats')
+            .leftJoinAndSelect('cats.toys', 'toys')
+            .leftJoinAndSelect('cats.home', 'home')
+            .where('home.name = :name', { name: 'Box' })
+
+        const prunedQueryBuilder = buildOptimizedCountQuery(queryBuilder.clone())
+
+        const keptAliases = prunedQueryBuilder.expressionMap.joinAttributes.map((join) => join.alias.name)
+        expect(keptAliases).toStrictEqual(['home'])
+        expect(await prunedQueryBuilder.getCount()).toBe(await queryBuilder.getCount())
     })
 
     it('should fix currentPage when page is out of bounds', async () => {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -14,6 +14,7 @@ import { WherePredicateOperator } from 'typeorm/query-builder/WhereClause'
 import { PaginateQuery } from './decorator'
 import { addFilter, AddFilterOptions, FilterComparator, FilterOperator, FilterQuantifier, FilterSuffix } from './filter'
 import {
+    buildOptimizedCountQuery,
     checkIsEmbedded,
     checkIsRelation,
     Column,
@@ -47,6 +48,7 @@ import globalConfig from './global-config'
 const logger: Logger = new Logger('nestjs-paginate')
 
 export { AddFilterOptions, FilterComparator, FilterOperator, FilterSuffix }
+export { buildOptimizedCountQuery }
 
 export class Paginated<T> {
     data: T[]
@@ -108,6 +110,7 @@ export interface PaginateConfig<T> {
     defaultJoinMethod?: JoinMethod
     joinMethods?: Partial<MappedColumns<T, JoinMethod>>
     buildCountQuery?: (qb: SelectQueryBuilder<T>) => SelectQueryBuilder<any>
+    optimizedCount?: boolean
     throwOnInvalidFilter?: boolean
 }
 
@@ -1036,9 +1039,10 @@ export async function paginate<T extends ObjectLiteral>(
     if (query.limit === PaginationLimit.COUNTER_ONLY) {
         totalItems = await queryBuilder.getCount()
     } else if (isPaginated && config.paginationType !== PaginationType.CURSOR) {
-        if (config.buildCountQuery) {
+        if (config.buildCountQuery || config.optimizedCount) {
+            const buildCountQuery = config.buildCountQuery ?? buildOptimizedCountQuery
             items = await queryBuilder.getMany()
-            totalItems = await config.buildCountQuery(queryBuilder.clone()).getCount()
+            totalItems = await buildCountQuery(queryBuilder.clone()).getCount()
         } else {
             ;[items, totalItems] = await queryBuilder.getManyAndCount()
         }


### PR DESCRIPTION
## Motivation

When a paginate config declares `relations` for hydration, `getManyAndCount()` runs the COUNT over the fully-joined statement. With one-to-many relations in the tree this becomes a `COUNT(DISTINCT(id))` across the entire join product, even though most of those joins cannot change the number of matching root entities.

We hit this on a production Postgres workload: a transactions list endpoint whose config joins ~20 tables for hydration was spending ~500 MB of buffer reads **per count execution**, while its WHERE clause only referenced the root table and two relations. The count query dominated the database's CPU profile (top query in RDS Performance Insights).

## What this does

`optimizedCount: true` builds the count from a clone of the main query with count-irrelevant joins removed:

- **LEFT JOINs** are kept only when the WHERE clause references their alias.
- **INNER JOINs** are always kept — they restrict the result set even when unreferenced.
- Parent chains of kept joins are preserved, so nested relations stay intact.
- ORDER BY is cleared, since ordering cannot change the count.

The page data query is unaffected. `buildCountQuery` still takes precedence when both are set, and the pruning helper is exported as `buildOptimizedCountQuery` so it can be composed inside a custom `buildCountQuery` too.

The WHERE clause is obtained via the protected `createWhereExpression()` (same protected-API approach as the existing `getExistsCondition` / `createWhereConditionExpression` usages) rather than parsing `getQuery()`, so virtual-column subqueries in the SELECT clause don't produce false positives.

It is opt-in and default-off, so existing behavior is unchanged.

## Tests

- `optimizedCount` returns identical `totalItems` and data as the default count, with relations configured and with filters through a relation.
- Join pruning keeps WHERE-referenced joins and drops unreferenced ones, with counts verified equal against the unpruned builder.

Ran the suite with `DB=postgres`: 335/336 pass — the one failure ("should return result sorted by a virtual column") also fails on a clean master checkout in my environment (postgres:latest), so it is unrelated to this change.