### PR TITLE
fix: support filtering on `json` columns (not just `jsonb`)

### DIFF
--- a/src/__tests__/cat-hair.entity.ts
+++ b/src/__tests__/cat-hair.entity.ts
@@ -18,6 +18,11 @@ export class CatHairEntity {
     @Column({ type: 'jsonb', nullable: true })
     metadata: Record<string, any>
 
+    // Plain `json` (not `jsonb`) column. Postgres `json` does not support the `@>`
+    // containment operator, so filtering must go through `#>>` text extraction.
+    @Column({ type: 'json', nullable: true })
+    metadataJson: Record<string, any>
+
     @OneToOne(() => CatHairEntity, (catFur) => catFur.underCoat, { nullable: true })
     @JoinColumn()
     underCoat: CatHairEntity

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -33,6 +33,7 @@ import {
     isDateColumnType,
     isISODate,
     JoinMethod,
+    JSON_COLUMN_TYPES,
     mergeRelationSchema,
     quoteColumn,
     resolveJsonbPath,
@@ -571,6 +572,16 @@ export function getRelationPath(
                 [fieldName, embedded] as const,
                 ...(relationSegments.length > 1 ? getRelationPath(deeper, embedded) : []),
             ]
+        }
+
+        // A JSON(B) column followed by a key path (e.g. `metadata.length`) is a direct filter,
+        // not a relation chain: the remaining segments index into the JSON value, they are not
+        // relations. Terminate the path here rather than treating `length` as a missing relation.
+        if ('findColumnWithPropertyName' in metadata) {
+            const columnType = metadata.findColumnWithPropertyName(fieldName)?.type
+            if (JSON_COLUMN_TYPES.includes(columnType as string)) {
+                return []
+            }
         }
     } catch (e) {
         if (e instanceof RelationPathError) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -262,6 +262,13 @@ export interface JsonbPathResolution {
 }
 
 /**
+ * Column data types treated as JSON. Both `jsonb` and plain `json` are supported:
+ * `#>>` path extraction works on both, and TypeORM's `JsonContains` ($eq/$in/$contains)
+ * emits `<column> ::jsonb @> :value`, which casts a `json` column to `jsonb` for free.
+ */
+const JSON_COLUMN_TYPES = ['jsonb', 'json']
+
+/**
  * Walks the dot-separated `column` path through TypeORM entity metadata to determine
  * whether the path terminates in a JSONB column and, if so, where the relation chain
  * ends and the JSON key path begins.
@@ -296,9 +303,9 @@ export function resolveJsonbPath(qb: SelectQueryBuilder<unknown>, column: string
             relationPath.push(segment)
             metadata = relation.inverseEntityMetadata
         } else {
-            // Not a relation — check whether it is a JSONB column
-            const isJsonbColumn = metadata?.findColumnWithPropertyName(segment)?.type === 'jsonb'
-            if (!isJsonbColumn) {
+            // Not a relation — check whether it is a JSON(B) column
+            const columnType = metadata?.findColumnWithPropertyName(segment)?.type
+            if (!JSON_COLUMN_TYPES.includes(columnType as string)) {
                 return notJsonb
             }
             return {
@@ -310,10 +317,10 @@ export function resolveJsonbPath(qb: SelectQueryBuilder<unknown>, column: string
         }
     }
 
-    // All segments except the last were relations; the last segment must be a JSONB column.
+    // All segments except the last were relations; the last segment must be a JSON(B) column.
     const lastSegment = parts[parts.length - 1]
-    const isJsonbColumn = metadata?.findColumnWithPropertyName(lastSegment)?.type === 'jsonb'
-    if (isJsonbColumn) {
+    const lastColumnType = metadata?.findColumnWithPropertyName(lastSegment)?.type
+    if (JSON_COLUMN_TYPES.includes(lastColumnType as string)) {
         return {
             isJsonb: true,
             relationPath,

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -266,7 +266,7 @@ export interface JsonbPathResolution {
  * `#>>` path extraction works on both, and TypeORM's `JsonContains` ($eq/$in/$contains)
  * emits `<column> ::jsonb @> :value`, which casts a `json` column to `jsonb` for free.
  */
-const JSON_COLUMN_TYPES = ['jsonb', 'json']
+export const JSON_COLUMN_TYPES = ['jsonb', 'json']
 
 /**
  * Walks the dot-separated `column` path through TypeORM entity metadata to determine

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -285,16 +285,19 @@ describe('paginate', () => {
                     name: 'short',
                     colors: ['white', 'brown', 'black'],
                     metadata: { length: 5, thickness: 1 },
+                    metadataJson: { length: 5, thickness: 1 },
                 }),
                 catHairRepo.create({
                     name: 'long',
                     colors: ['white', 'brown'],
                     metadata: { length: 20, thickness: 5 },
+                    metadataJson: { length: 20, thickness: 5 },
                 }),
                 catHairRepo.create({
                     name: 'buzzed',
                     colors: ['white'],
                     metadata: { length: 0.5, thickness: 10 },
+                    metadataJson: { length: 0.5, thickness: 10 },
                 }),
                 catHairRepo.create({ name: 'none' }),
             ])
@@ -3921,6 +3924,114 @@ describe('paginate', () => {
                 expect(result.data).toHaveLength(2)
                 expect(result.data).toEqual(expect.arrayContaining([catHairs[0], catHairs[1]]))
                 expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadata.length=$in:5,20')
+            })
+        })
+    }
+
+    if (process.env.DB === 'postgres') {
+        // Plain `json` columns (as opposed to `jsonb`) do not support the Postgres `@>`
+        // containment operator, so $eq/$in must be routed through `#>>` text extraction
+        // rather than TypeORM's JsonContains. These mirror the jsonb cases above.
+        describe('should be able to filter on json (non-jsonb) columns', () => {
+            it('should filter a direct json column with a single value', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadataJson.length': true,
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'metadataJson.length': '$eq:5',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadataJson.length': '$eq:5',
+                })
+                expect(result.data).toStrictEqual([catHairs[0]])
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadataJson.length=$eq:5')
+            })
+
+            it('should filter a direct json column with multiple values', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadataJson.length': true,
+                        'metadataJson.thickness': true,
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'metadataJson.length': '$eq:0.5',
+                        'metadataJson.thickness': '$eq:10',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadataJson.length': '$eq:0.5',
+                    'metadataJson.thickness': '$eq:10',
+                })
+                expect(result.data).toStrictEqual([catHairs[2]])
+                expect(result.links.current).toBe(
+                    '?page=1&limit=20&sortBy=id:ASC&filter.metadataJson.length=$eq:0.5&filter.metadataJson.thickness=$eq:10'
+                )
+            })
+
+            it('should filter a direct json column using $in', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadataJson.length': [FilterOperator.EQ, FilterOperator.IN],
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'metadataJson.length': '$in:5,20',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadataJson.length': '$in:5,20',
+                })
+                expect(result.data).toHaveLength(2)
+                expect(result.data).toEqual(expect.arrayContaining([catHairs[0], catHairs[1]]))
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadataJson.length=$in:5,20')
+            })
+
+            it('should filter a json column through a relation (self-referencing entity)', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'underCoat.metadataJson.length': true,
+                    },
+                    relations: ['underCoat'],
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        'underCoat.metadataJson.length': '$eq:5',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'underCoat.metadataJson.length': '$eq:5',
+                })
+                expect(result.data).toStrictEqual([underCoats[0]])
+                expect(result.links.current).toBe(
+                    '?page=1&limit=20&sortBy=id:ASC&filter.underCoat.metadataJson.length=$eq:5'
+                )
             })
         })
     }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3925,6 +3925,34 @@ describe('paginate', () => {
                 expect(result.data).toEqual(expect.arrayContaining([catHairs[0], catHairs[1]]))
                 expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadata.length=$in:5,20')
             })
+
+            // Operators other than $eq/$in/$contains use the `#>>` extraction path instead of
+            // JsonContains. That path keys the filter on the full `column.key` path, which the
+            // relation resolver used to reject ("No relation or embedded found"). Extraction
+            // operators must work on JSON key paths too.
+            it('should filter on a direct JSONB column using an extraction operator ($sw)', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadata.length': [FilterOperator.SW],
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        // length values are 5, 20, 0.5 → only '20' starts with '2'
+                        'metadata.length': '$sw:2',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadata.length': '$sw:2',
+                })
+                expect(result.data).toStrictEqual([catHairs[1]])
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadata.length=$sw:2')
+            })
         })
     }
 
@@ -4032,6 +4060,34 @@ describe('paginate', () => {
                 expect(result.links.current).toBe(
                     '?page=1&limit=20&sortBy=id:ASC&filter.underCoat.metadataJson.length=$eq:5'
                 )
+            })
+
+            // Same extraction path as above, but on a camel-cased column. TypeORM escapes the
+            // `alias.column` token inside the `#>>` expression, so camel-casing is not itself a
+            // separate problem — this guards that extraction filtering keeps working on a
+            // realistic camel-cased json column.
+            it('should filter a camel-cased json column via an extraction operator ($sw)', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'metadataJson.length': [FilterOperator.SW],
+                    },
+                }
+                const query: PaginateQuery = {
+                    path: '',
+                    filter: {
+                        // length values are 5, 20, 0.5 → only '20' starts with '2'
+                        'metadataJson.length': '$sw:2',
+                    },
+                }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.filter).toStrictEqual({
+                    'metadataJson.length': '$sw:2',
+                })
+                expect(result.data).toStrictEqual([catHairs[1]])
+                expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&filter.metadataJson.length=$sw:2')
             })
         })
     }


### PR DESCRIPTION
## Summary

Filtering only worked on `jsonb` columns; plain `json` columns were silently treated as non-JSON paths and produced invalid SQL. This adds full `json` support and fixes a related gap that affected `jsonb` too.

Two commits:

**1. Support filtering on plain `json` columns**
`resolveJsonbPath` only matched columns whose TypeORM type was exactly `jsonb`. It now also matches `json`:
- `#>>` path extraction works on `json` natively.
- TypeORM's `JsonContains` (`$eq`/`$in`/`$contains`) emits `<column> ::jsonb @> :value`, which casts `json` to `jsonb` for free.

**2. Support extraction-operator filters on JSON key paths**
Operators other than `$eq`/`$in`/`$contains` (e.g. `$gt`, `$sw`, `$lte`) use the `#>>` extraction path, which keys the filter on the full `column.key` path (e.g. `metadata.length`). `getRelationPath` rejected this with *"No relation or embedded found"*, treating the JSON key as a missing relation segment. The path resolver now terminates at a `json`/`jsonb` column and treats the remaining segments as the JSON key path. **This affected `jsonb` columns as well, not just `json`.**

## Tests

New Postgres tests in `paginate.spec.ts`:
- Direct and through-relation `json` filtering with `$eq`, multiple keys, and `$in`.
- Extraction-operator (`$sw`) filtering on a lower-cased `jsonb` column and a camel-cased `json` column.

Each new test fails on the unfixed code and passes with the fix. Full suite green on Postgres and SQLite; lint and prettier clean.