### PR TITLE
fix(test): make MariaDB cursor date tests host-timezone independent

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -98,6 +98,9 @@ describe('paginate', () => {
                 dataSource = new DataSource({
                     ...dbOptions,
                     type: 'mariadb',
+                    // Store/read dates in UTC so the fixed cursor tokens in the cursor
+                    // tests are correct regardless of the host machine's timezone.
+                    timezone: 'Z',
                     host: process.env.DB_HOST || 'localhost',
                     port: +process.env.MARIA_DB_PORT || 3306,
                     username: process.env.DB_USERNAME || 'root',


### PR DESCRIPTION
## Summary

The cursor-pagination tests over the `lastVetVisit` date column fail on **non-UTC developer machines** (they pass on UTC CI runners). Affected:

- `should handle date type cursor column (lastVetVisit, ASC)`
- `should handle multiple cursor columns checking combined cursor (age:ASC, lastVetVisit:ASC)`

## Root cause

Those tests assert fixed cursor tokens (e.g. `V998328556000000`) that encode the seeded timestamps as epoch-milliseconds, computed in SQL via `UNIX_TIMESTAMP(col) * 1000`.

The MariaDB driver serializes JS `Date` params using the **Node process's local timezone**. On a host at, say, Europe/Rome (UTC+1), the seed `2022-12-19T10:00:00.000Z` is written as `2022-12-19 11:00:00`, so `UNIX_TIMESTAMP` returns a value shifted by the host offset. That shift moves the row's computed cursor across the strict boundary comparison (`cursorExpr < :cursor`), leaking the boundary row into the next page.

Entity read-back un-shifts the value (so `result.data` timestamps *look* correct), which is why this masquerades as a precision issue — but the cursor arithmetic runs on the raw, shifted column. It is purely host-timezone dependent, not a MariaDB version or column-precision issue.

## Fix

Pin the MariaDB **test** datasource to UTC with `timezone: 'Z'` (test-only; no production `src/*.ts` touched). Seed values then store as `2022-12-19 10:00:00`, `UNIX_TIMESTAMP` matches the fixed tokens exactly, and the strict boundary excludes the boundary row as intended.

## Verification

- **MariaDB**: full suite green, both target tests failing → passing (plus the DESC reverse-order test).
- **SQLite**: full suite unaffected.
- **Postgres**: unaffected (only the known pre-existing `sorted by a virtual column` tie-order flake remains).
- `format:ci`, `lint`, `build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)