### PR TITLE
fix: resolve embedded column selects beyond the first relation level

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -96,29 +96,42 @@ export function isEntityKey<T>(entityColumns: Column<T>[], column: string): colu
 export const positiveNumberOrDefault = (value: number | undefined, defaultValue: number, minValue: 0 | 1 = 0) =>
     value === undefined || value < minValue ? defaultValue : value
 
-export type ColumnProperties = { propertyPath?: string; propertyName: string; isNested: boolean; column: string }
+export type ColumnProperties = {
+    propertyPath?: string
+    propertyName: string
+    isNested: boolean
+    column: string
+    /**
+     * The dot path of the embedded column, when the column was written with the `(...)` notation,
+     * e.g. `size.height` for `toys.(size.height)`. Undefined when no embedded notation is used.
+     */
+    embeddedPath?: string
+}
+
+const stripEmbeddedParentheses = (path: string) => path.replace('(', '').replace(')', '')
 
 export function getPropertiesByColumnName(column: string): ColumnProperties {
-    const propertyPath = column.split('.')
-    if (propertyPath.length > 1) {
-        const propertyNamePath = propertyPath.slice(1)
-        let isNested = false,
-            propertyName = propertyNamePath.join('.')
+    const segments = column.split('.')
+    if (segments.length === 1) {
+        return { propertyName: segments[0], isNested: false, column: segments[0] }
+    }
 
-        if (!propertyName.startsWith('(') && propertyNamePath.length > 1) {
-            isNested = true
-        }
+    // The `(...)` notation opens on the segment where the embedded path starts, so every segment
+    // before it is a relation. Without the notation only the last segment is a column.
+    const embeddedStart = segments.findIndex((segment) => segment.startsWith('('))
+    const embeddedPath =
+        embeddedStart === -1 ? undefined : stripEmbeddedParentheses(segments.slice(embeddedStart).join('.'))
+    const relationSegments = embeddedStart === -1 ? segments.slice(0, -1) : segments.slice(0, embeddedStart)
 
-        propertyName = propertyName.replace('(', '').replace(')', '')
+    const propertyPath = stripEmbeddedParentheses(segments[0])
+    const propertyName = stripEmbeddedParentheses(segments.slice(1).join('.'))
 
-        return {
-            propertyPath: propertyPath[0],
-            propertyName, // the join is in case of an embedded entity
-            isNested,
-            column: `${propertyPath[0]}.${propertyName}`,
-        }
-    } else {
-        return { propertyName: propertyPath[0], isNested: false, column: propertyPath[0] }
+    return {
+        propertyPath,
+        propertyName,
+        isNested: relationSegments.length > 1,
+        column: `${propertyPath}.${propertyName}`,
+        embeddedPath,
     }
 }
 
@@ -376,11 +389,14 @@ export function fixColumnAlias(
         } else if ((isVirtualProperty && !query) || properties.isNested) {
             if (properties.propertyName.includes('.')) {
                 const propertyPath = properties.propertyName.split('.')
+                // An embedded path is part of the column, not of the relation chain, so it must not
+                // be turned into join aliases.
+                const columnSegments = properties.embeddedPath?.split('.').length ?? 1
                 const nestedRelations = propertyPath
-                    .slice(0, -1)
+                    .slice(0, -columnSegments)
                     .map((v) => `${v}_rel`)
                     .join('_')
-                const nestedCol = propertyPath[propertyPath.length - 1]
+                const nestedCol = propertyPath.slice(-columnSegments).join('.')
 
                 return `${alias}_${properties.propertyPath}_rel_${nestedRelations}.${nestedCol}`
             } else {

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -1799,6 +1799,22 @@ describe('paginate', () => {
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=cat.(size.height):DESC')
     })
 
+    it('should return result based on filter on embedded entity on a nested relation', async () => {
+        const config: PaginateConfig<CatHomePillowEntity> = {
+            sortableColumns: ['id'],
+            relations: { home: { cat: true } },
+            filterableColumns: { 'home.cat.(size.height)': true },
+        }
+        const query: PaginateQuery = {
+            path: '',
+            filter: { 'home.cat.(size.height)': '$gte:30' },
+        }
+
+        const result = await paginate<CatHomePillowEntity>(query, catHomePillowRepo, config)
+
+        expect(result.data.map((pillow) => pillow.color)).toStrictEqual(['pink', 'purple', 'teal'])
+    })
+
     it('should return result based on search on embedded entity', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id', 'name', 'size.height', 'size.length', 'size.width'],
@@ -2790,6 +2806,43 @@ describe('paginate', () => {
         })
         expect(result.meta.select).toStrictEqual(['id', 'toys.(size.height)'])
         expect(result.links.current).toBe('?page=1&limit=20&sortBy=id:ASC&select=id,toys.(size.height)')
+    })
+
+    it.each([['size.height'], ['(size.height)']])('should return the selected embedded column %s', async (column) => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            select: ['id', column],
+        }
+        const query: PaginateQuery = { path: '' }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        result.data.forEach((cat) => {
+            expect(cat.name).not.toBeDefined()
+            expect(cat.size.height).toBeDefined()
+            expect(cat.size.width).not.toBeDefined()
+        })
+    })
+
+    it('should return selected embedded columns on a nested relation', async () => {
+        const config: PaginateConfig<CatHomeEntity> = {
+            sortableColumns: ['id'],
+            select: ['id', 'cat.id', 'cat.toys.id', 'cat.toys.(size.height)'],
+            relations: { cat: { toys: true } },
+        }
+        const query: PaginateQuery = { path: '' }
+
+        const result = await paginate<CatHomeEntity>(query, catHomeRepo, config)
+
+        const home = result.data.find((home) => home.id === catHomes[0].id)
+        expect(home.name).not.toBeDefined()
+        expect(home.cat.id).toBe(cats[0].id)
+        expect(home.cat.name).not.toBeDefined()
+
+        const toy = home.cat.toys.find((toy) => toy.id === catToys[0].id)
+        expect(toy.name).not.toBeDefined()
+        expect(toy.size.height).toBe(catToys[0].size.height)
+        expect(toy.size.width).not.toBeDefined()
     })
 
     it('should only select columns via query which are selected in config', async () => {
@@ -5182,6 +5235,28 @@ describe('paginate', () => {
             expect(result.data[0].toys[0]).toHaveProperty('size.height')
             expect(result.data[0].toys[0]).toHaveProperty('size.width')
             expect(result.data[0].toys[0]).toHaveProperty('size.length')
+        })
+
+        it('should expand nestedRelation.* wildcard to all relation columns', async () => {
+            const query: PaginateQuery = {
+                page: 1,
+                limit: 10,
+                select: ['id', 'cat.id', 'cat.toys.*'],
+                path: '/cat-homes',
+            }
+
+            const result = await paginate(query, catHomeRepo, {
+                sortableColumns: ['id'],
+                select: ['id', 'cat.id', 'cat.toys.*'],
+                relations: { cat: { toys: true } },
+            })
+
+            const toy = result.data[0].cat.toys[0]
+            expect(toy).toHaveProperty('id')
+            expect(toy).toHaveProperty('name')
+            expect(toy).toHaveProperty('size.height')
+            expect(toy).toHaveProperty('size.width')
+            expect(toy).toHaveProperty('size.length')
         })
 
         it('should handle both * and relation.* wildcards together', async () => {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -935,8 +935,17 @@ export async function paginate<T extends ObjectLiteral>(
         let cols: string[] = selectParams.reduce((cols, currentCol) => {
             const columnProperties = getPropertiesByColumnName(currentCol)
             const isRelation = checkIsRelation(queryBuilder, columnProperties.propertyPath)
+            const isEmbedded = checkIsEmbedded(queryBuilder, columnProperties.propertyPath)
             cols.push(
-                fixColumnAlias(columnProperties, queryBuilder.alias, isRelation, false, false, undefined, queryBuilder)
+                fixColumnAlias(
+                    columnProperties,
+                    queryBuilder.alias,
+                    isRelation,
+                    false,
+                    isEmbedded,
+                    undefined,
+                    queryBuilder
+                )
             )
             return cols
         }, [])


### PR DESCRIPTION
Fixes #1148

## The bug

`select: ['lists.users.(name.first)']` fails with `Unknown column '__root_lists_rel_users_rel_name_rel.first'`. The `(...)` notation works at the root and on a first-level relation, but not deeper.

`getPropertiesByColumnName` strips the parentheses and then throws the boundary away, keeping only `propertyPath` (the first segment) and a flat `propertyName`. `fixColumnAlias` therefore cannot tell an embedded path from a relation hop, and its nested branch turns *every* intermediate segment into a `_rel` join alias:

```
cat.toys.(size.height)  ->  __root_cat_rel_toys_rel_size_rel.height   ❌
                            __root_cat_rel_toys_rel.size.height       ✅
```

One relation level happens to work only because `propertyName` then starts with `(`, which short-circuits `isNested` to `false` and takes the non-nested branch.

## The fix

`ColumnProperties` now carries an `embeddedPath` (the dot path that was inside the parentheses), and `fixColumnAlias` keeps those trailing segments as part of the column name instead of expanding them into join aliases. `isNested` is derived from the number of *relation* segments, which also fixes it for root-level embeds written as `(a.b.c)`.

Two things fall out of the same root cause:

- **Wildcard selects on nested relations.** `expandWildcardSelect` emits `<path>.(<embed>.<col>)`, so `select: ['cat.toys.*']` hit the identical error whenever the nested relation had an embedded entity.
- **Root-level embedded selects.** The `select` call site never passed `isEmbedded` to `fixColumnAlias`, so `size.height` resolved to `__root.height`. TypeORM emitted `"__root"."sizeHeight"` with no alias, and the column was silently dropped during hydration — `select: ['id', 'size.height']` returned `{ id: 1 }` with no `size` at all. No error, just missing data.

## Tests

Four tests in `paginate.spec.ts`, all failing on `master` except the last:

- `should return the selected embedded column size.height` / `(size.height)` — root-level, both notations.
- `should return selected embedded columns on a nested relation` — the reported case, `cat.toys.(size.height)`.
- `should expand nestedRelation.* wildcard to all relation columns` — `cat.toys.*`.
- `should return result based on filter on embedded entity on a nested relation` — passes on `master`; added to pin the filter path against the parsing rewrite.

Green on sqlite, postgres and mariadb locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)