### PR TITLE
fix(test): break the virtual-column sort tie so the assertion is deterministic

### DIFF
--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3946,12 +3946,19 @@ describe('paginate', () => {
 
         it('should return result sorted by a virtual column', async () => {
             const config: PaginateConfig<CatEntity> = {
-                sortableColumns: ['home.countCat'],
+                sortableColumns: ['home.countCat', 'id'],
                 relations: { home: { naptimePillow: { brand: true } } },
             }
             const query: PaginateQuery = {
+                // `home.countCat` is 1 for the three cats that have a home and null for the four
+                // that do not, so it alone leaves both groups tied. Break the tie on `id` to pin a
+                // single valid ordering; without it the database may return either group in any
+                // order and the assertion below only passes by accident.
                 path: '',
-                sortBy: [['home.countCat', 'ASC']],
+                sortBy: [
+                    ['home.countCat', 'ASC'],
+                    ['id', 'ASC'],
+                ],
             }
 
             const result = await paginate<CatEntity>(query, catRepo, config)
@@ -3970,7 +3977,7 @@ describe('paginate', () => {
             expect(result.data).toStrictEqual(expectedResult)
             expect(result.links.last).toBeUndefined()
             expect(result.links.next).toBeUndefined()
-            expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC')
+            expect(result.links.current).toBe('?page=1&limit=20&sortBy=home.countCat:ASC&sortBy=id:ASC')
         })
     })
 


### PR DESCRIPTION
`should return result sorted by a virtual column` sorts only by `home.countCat`:

```ts
sortableColumns: ['home.countCat'],
sortBy: [['home.countCat', 'ASC']],
expectedResult = [3, 4, 5, 6, 0, 1, 2]   // one arbitrary permutation, pinned
```

That column is `1` for the three cats that have a home and `null` for the four that do not. So the `ORDER BY` constrains nothing beyond "nulls before ones" — both groups are fully tied, and the assertion pins one arbitrary permutation of each.

Without a tie-breaker the server may return either tie group in any order. The test therefore passes or fails depending on the physical row order it happens to produce, on identical code:

```
master, unchanged, postgres A  →  294 passed
master, unchanged, postgres B  →  1 failed  (this test)
master, + tie-break, postgres B →  294 passed
```

Sorting by `id` as a secondary key leaves exactly one valid ordering. The expected array is unchanged — it was already in `id` order within each group — so this pins the intent rather than rewriting it.

Same class as the ordering issue diagnosed in #1112 (`leftJoinAndSelect` returning child rows in unspecified order without an explicit `ORDER BY`, where the expectation had been pinned to whatever Postgres happened to return), and as the host-timezone dependence fixed in #1153: a test asserting on something the query never actually constrained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)