### PR TITLE
fix: join the junction table for a ManyToMany behind a to-one relation

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -995,6 +995,20 @@ export function addToManySubFilters<T>(
                     // --- Intermediate Join ---
                     const parentAlias = relAlias(relationPath[i - 1][0], i - 1)
                     const childAlias = relAlias(relationPath[i][0], i)
+                    if (parentMeta.isManyToMany) {
+                        // A ManyToMany has no foreign key to join on: the pairing lives in the
+                        // junction table, which has to be joined between child and parent. Without
+                        // it the ON condition below would be empty (`joinColumns` is empty on the
+                        // inverse side), degrading the join to a cross product that matches any row.
+                        joinManyToManyToParent(
+                            existsQb,
+                            parentMeta,
+                            childAlias,
+                            parentAlias,
+                            juncAlias(relationPath[i][0], i)
+                        )
+                        continue
+                    }
                     const childRelationMetadata = parentMeta.inverseRelation
                     const joinCols = childRelationMetadata.joinColumns
                     const onConditions = joinCols
@@ -1013,6 +1027,50 @@ export function addToManySubFilters<T>(
                     correlateManyToManyOrFk(existsQb, parentMeta, relAlias, juncAlias)
                 }
             }
+        }
+
+        /**
+         * JOINs an intermediate ManyToMany into the EXISTS subquery: the junction table, and then
+         * the entity that declares the relation. The column roles are the same as at the root
+         * (see correlateManyToManyOrFk), except the far side is another joined alias rather than
+         * the main query's.
+         */
+        function joinManyToManyToParent(
+            existsQb: SelectQueryBuilder<any>,
+            parentMeta: RelationMetadata,
+            childAlias: string,
+            parentAlias: string,
+            junctionAlias: string
+        ) {
+            if (!parentMeta.isOwning && !parentMeta.inverseRelation) {
+                throw new Error(
+                    `Cannot build EXISTS subquery for ManyToMany relation "${path}": ` +
+                        `the relation has no inverse side defined. ` +
+                        `Ensure the @ManyToMany decorator on the inverse entity references this relation.`
+                )
+            }
+            // Junction metadata lives only on the owning side, whichever side the filter came from.
+            const joinMeta = parentMeta.isOwning ? parentMeta : parentMeta.inverseRelation
+            const toChildCols = parentMeta.isOwning ? joinMeta.inverseJoinColumns : joinMeta.joinColumns
+            const toParentCols = parentMeta.isOwning ? joinMeta.joinColumns : joinMeta.inverseJoinColumns
+
+            const on = (cols: typeof toChildCols, alias: string) =>
+                cols
+                    .map(
+                        (jc) =>
+                            `${quote(junctionAlias)}.${quote(jc.databaseName)} = ${quote(alias)}.${quote(
+                                jc.referencedColumn.databaseName
+                            )}`
+                    )
+                    .join(' AND ')
+
+            const junctionMeta = joinMeta.junctionEntityMetadata
+            existsQb.innerJoin(
+                junctionMeta.target ?? junctionMeta.tableName,
+                junctionAlias,
+                on(toChildCols, childAlias)
+            )
+            existsQb.innerJoin(parentMeta.entityMetadata.target, parentAlias, on(toParentCols, parentAlias))
         }
 
         /**

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -5609,6 +5609,26 @@ describe('paginate', () => {
                 expect(result.data[0].id).toBe(cats[0].id)
             })
 
+            it('should find cats whose best friend has Garfield as a friend (to-one then ManyToMany)', async () => {
+                const config: PaginateConfig<CatEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: {
+                        'bestFriend.friends.name': [FilterOperator.EQ],
+                    },
+                }
+                const query: PaginateQuery = {
+                    filter: {
+                        'bestFriend.friends.name': '$eq:Garfield',
+                    },
+                    path: '',
+                }
+
+                const result = await paginate<CatEntity>(query, catRepo, config)
+                // Milo (cats[0]) is the only cat with friends, and Adam (cats[6]) is the only cat
+                // whose bestFriend is Milo.
+                expect(result.data.map((cat) => cat.id)).toStrictEqual([cats[6].id])
+            })
+
             it('should find cats that are a friend of Milo (ManyToMany inverse side)', async () => {
                 // cats[0] (Milo) has friends cats[1..6]; so cats[1..6] have Milo in their friendOf relation.
                 // Filtering on friendOf.name = 'Milo' should return cats[1..6].


### PR DESCRIPTION
### The bug

A filter on a column past a `ManyToMany` that is **not the first relation of the path** silently matches every row that merely has the leading relation — the predicate is ignored entirely.

```ts
filterableColumns: { 'bestFriend.friends.name': [FilterOperator.EQ] }
// filter.bestFriend.friends.name=$eq:Garfield
```

Only Milo has friends, and only Adam has Milo as `bestFriend`, so this must return Adam. It returns **every cat that has a bestFriend**, whoever their friends are. The request is not rejected — it is a 200 with the unfiltered set, so a caller cannot tell the filter did nothing.

### Why

`buildSubqueryJoinChain` correlates the *root* of the path with `correlateManyToManyOrFk`, which knows a `ManyToMany` pairs its sides through a junction table. Every *intermediate* relation, though, is joined straight from `inverseRelation.joinColumns` — foreign keys a `ManyToMany` does not have. The inverse side's `joinColumns` is empty, so the ON condition collapses to `''` and the join becomes a cross product:

```sql
EXISTS (SELECT 1 FROM "cat" friend
        INNER JOIN "cat" bestFriend ON bestFriend."deletedAt" IS NULL   -- no ON condition
        WHERE friend."name" = 'Garfield'
          AND "__root"."bestFriendId" = bestFriend."id")
```

which reads "some cat is named Garfield" AND "the row has a bestFriend".

This is why the neighbouring shapes are fine and hid it:
- a `ManyToMany` at the **head** of the path (`friends.name`) is correlated by the root helper;
- a `OneToMany` **anywhere** (`home.pillows.color`) has a real foreign key to join on.

Only to-one → `ManyToMany` → column was broken, and nothing covered it.

### The fix

Join the junction table between child and parent, reusing the root helper's column-role mapping (junction metadata lives on the owning side, whichever side the filter is expressed from).

```sql
EXISTS (SELECT 1 FROM cat friend
        INNER JOIN cat_friends_cat junc ON junc."catId_2" = friend."id"
        INNER JOIN cat bestFriend      ON junc."catId_1" = bestFriend."id"
        WHERE friend."name" = ? AND "__root"."bestFriendId" = bestFriend."id")
```

### Tests

Adds the uncovered shape (`bestFriend.friends.name`). Green on all three databases (sqlite / postgres / mariadb); the one failing Postgres test is the pre-existing virtual-column sort tie, which fails identically on an untouched `master` and is fixed by #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)