### PR TITLE
fix: refuse filters and sorts that cannot be compiled to SQL

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -31,6 +31,7 @@ import {
     extractVirtualProperty,
     fixColumnAlias,
     getPropertiesByColumnName,
+    isBareJsonColumn,
     isDateColumnType,
     isISODate,
     JoinMethod,
@@ -428,9 +429,23 @@ export function parseFilter<T>(
         const allowedOperators = filterableColumns[column]
         const input = query.filter[column]
         const statements = !Array.isArray(input) ? [input] : input
+        // A `json` column has no equality or comparison operators in Postgres, so a value filter on
+        // the column itself compiles to SQL that cannot run (`operator does not exist: json = unknown`).
+        // Only its emptiness is askable; its contents are reached through a key path. This holds
+        // whatever the allowlist says — the blanket `true` included.
+        const bareJson = qb ? isBareJsonColumn(qb.expressionMap.mainAlias.metadata, column) : false
         for (const raw of statements) {
             const token = parseFilterToken(raw)
             if (!token) {
+                continue
+            }
+            if (bareJson && token.operator !== FilterOperator.NULL) {
+                if (throwOnInvalidFilter) {
+                    throw new BadRequestException(
+                        `Column '${column}' is a json column and cannot be compared as a value; ` +
+                            `filter a key path (e.g. '${column}.<key>') or use '$null'`
+                    )
+                }
                 continue
             }
             if (allowedOperators === true) {
@@ -449,11 +464,16 @@ export function parseFilter<T>(
                     continue
                 }
             } else {
-                if (
-                    token.operator &&
-                    token.operator !== FilterOperator.EQ &&
-                    !allowedOperators.includes(token.operator)
-                ) {
+                // `$eq` is the implicit default operator: it is what a suffix negates (`$not:John`)
+                // and what a quantifier quantifies (`$none:red`), named or not. A whitelisted
+                // modifier therefore licenses the `$eq` it modifies, or `[FilterSuffix.NOT]` and
+                // `[FilterQuantifier.NONE]` would be undeclarable. It licenses no more than that:
+                // a standalone `$eq`, bare or spelled out, is whitelisted like any other operator.
+                const licensedByModifier =
+                    token.operator === FilterOperator.EQ &&
+                    ((!!token.suffix && allowedOperators.includes(token.suffix)) ||
+                        allowedOperators.includes(token.quantifier))
+                if (token.operator && !licensedByModifier && !allowedOperators.includes(token.operator)) {
                     if (throwOnInvalidFilter) {
                         throw new BadRequestException(
                             `Filter operator '${token.operator}' is not allowed for column '${column}'`

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -606,16 +606,25 @@ function resolveTerminal(metadata: EntityMetadata, column: string): { isRelation
 }
 
 /**
- * Whether a row can be ordered by `column` — whether it names one comparable value.
+ * Whether a row can be ordered by `column` — whether it names one value.
  *
  * A path that ends on a relation names no value of its own, and TypeORM compiles it to an ORDER BY
  * over a column its paginated DISTINCT subquery never selects (`column distinctAlias.__root_<fk>
- * does not exist`). A Postgres `json` column has no ordering operators at all. Ordering *through* a
- * to-many (`toys.id`) names a value and stays allowed.
+ * does not exist`). Ordering *through* a to-many (`toys.id`) does name a value and stays allowed,
+ * as does a `json` column, which is ordered as `jsonb` (see orderableColumnExpression).
  */
 export function isOrderableColumn(metadata: EntityMetadata, column: string): boolean {
-    const { isRelation, columnType } = resolveTerminal(metadata, column)
-    return !isRelation && columnType !== 'json'
+    return !resolveTerminal(metadata, column).isRelation
+}
+
+/**
+ * Whether ordering by `column` needs it cast. Postgres `json` has no ordering operators, `jsonb`
+ * has a total order, and the cast between them is exact — so a `json` column is ordered as `jsonb`
+ * rather than refused, and sorts like the `jsonb` column beside it.
+ */
+export function needsJsonbSortCast(qb: SelectQueryBuilder<unknown>, column: string): boolean {
+    if (!['postgres', 'cockroachdb'].includes(qb.connection.options.type)) return false
+    return resolveTerminal(qb.expressionMap.mainAlias.metadata, column).columnType === 'json'
 }
 
 /**

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,12 @@
 import { mergeWith } from 'lodash'
-import { FindOperator, FindOptionsRelations, ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm'
+import {
+    EntityMetadata,
+    FindOperator,
+    FindOptionsRelations,
+    ObjectLiteral,
+    Repository,
+    SelectQueryBuilder,
+} from 'typeorm'
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
 import { OrmUtils } from 'typeorm/util/OrmUtils'
 
@@ -574,4 +581,49 @@ export function buildOptimizedCountQuery<T extends ObjectLiteral>(qb: SelectQuer
 
     qb.expressionMap.joinAttributes = joins.filter((join) => kept.has(join.alias.name))
     return qb
+}
+
+/**
+ * Walks `column` through the entity metadata and reports what it terminates on: a relation, or a
+ * column of a given type. Anything that does not resolve — an embedded path, a virtual column, a
+ * JSON key path, a computed expression — reports neither, and is left to the caller's allowlist.
+ */
+function resolveTerminal(metadata: EntityMetadata, column: string): { isRelation?: true; columnType?: string } {
+    const parts = column.split('.')
+    let meta = metadata
+    for (let i = 0; i < parts.length; i++) {
+        const relation = meta.relations.find((r) => r.propertyPath === parts[i])
+        if (relation) {
+            if (i === parts.length - 1) return { isRelation: true }
+            meta = relation.inverseEntityMetadata
+            continue
+        }
+        const col = meta.columns.find((c) => c.propertyName === parts[i])
+        if (!col || i !== parts.length - 1) return {}
+        return { columnType: col.type as string }
+    }
+    return {}
+}
+
+/**
+ * Whether a row can be ordered by `column` — whether it names one comparable value.
+ *
+ * A path that ends on a relation names no value of its own, and TypeORM compiles it to an ORDER BY
+ * over a column its paginated DISTINCT subquery never selects (`column distinctAlias.__root_<fk>
+ * does not exist`). A Postgres `json` column has no ordering operators at all. Ordering *through* a
+ * to-many (`toys.id`) names a value and stays allowed.
+ */
+export function isOrderableColumn(metadata: EntityMetadata, column: string): boolean {
+    const { isRelation, columnType } = resolveTerminal(metadata, column)
+    return !isRelation && columnType !== 'json'
+}
+
+/**
+ * Whether `column` names a Postgres `json` column itself rather than a key path into one. Such a
+ * column has no equality or comparison operators — there is no `json = unknown` — so a value filter
+ * on it cannot be compiled at all. A key path (`col.key`) is read out as text and is fine, as is
+ * `$null`. `jsonb`, which does have those operators, is unaffected.
+ */
+export function isBareJsonColumn(metadata: EntityMetadata, column: string): boolean {
+    return resolveTerminal(metadata, column).columnType === 'json'
 }

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3875,6 +3875,25 @@ describe('paginate', () => {
                 expect(result.data.length).toBeGreaterThan(0)
             })
 
+            it.each(['metadata', 'metadataJson'] as const)(
+                'should order by a %s column with a relation joined and paginated',
+                async (column) => {
+                    // `take` + a join wraps the query in a DISTINCT subquery, and every ORDER BY has
+                    // to resolve back to a selected column. A raw cast expression does not.
+                    const config: PaginateConfig<CatHairEntity> = {
+                        sortableColumns: ['id', column],
+                        relations: { underCoat: true },
+                        defaultLimit: 2,
+                    }
+                    const query: PaginateQuery = { path: '', limit: 2, sortBy: [[column, 'DESC']] }
+
+                    const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                    expect(result.meta.sortBy).toStrictEqual([[column, 'DESC']])
+                    expect(result.data.length).toBe(2)
+                }
+            )
+
             it('should not let an un-whitelisted $eq reach an array column (#1109)', async () => {
                 // `$eq:1` against `text[]` is `malformed array literal`. It reached the database
                 // because `$eq` bypassed the allowlist entirely (#1111).

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -3859,16 +3859,35 @@ describe('paginate', () => {
                 expect(result.data.every((hair) => hair.metadataJson === null)).toBe(true)
             })
 
-            it('should not order by a json column', async () => {
+            it.each(['metadata', 'metadataJson'] as const)('should order by a %s column', async (column) => {
+                // `jsonb` has a total order and `json` has none, but the cast between them is exact,
+                // so both sort. Postgres would otherwise fail with `could not identify an ordering
+                // operator for type json`.
                 const config: PaginateConfig<CatHairEntity> = {
-                    sortableColumns: ['id', 'metadataJson'],
+                    sortableColumns: ['id', column],
                     defaultSortBy: [['id', 'ASC']],
                 }
-                const query: PaginateQuery = { path: '', sortBy: [['metadataJson', 'DESC']] }
+                const query: PaginateQuery = { path: '', sortBy: [[column, 'DESC']] }
 
                 const result = await paginate<CatHairEntity>(query, catHairRepo, config)
 
-                expect(result.meta.sortBy).toStrictEqual([['id', 'ASC']])
+                expect(result.meta.sortBy).toStrictEqual([[column, 'DESC']])
+                expect(result.data.length).toBeGreaterThan(0)
+            })
+
+            it('should not let an un-whitelisted $eq reach an array column (#1109)', async () => {
+                // `$eq:1` against `text[]` is `malformed array literal`. It reached the database
+                // because `$eq` bypassed the allowlist entirely (#1111).
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: { colors: [FilterOperator.CONTAINS] },
+                    throwOnInvalidFilter: true,
+                }
+                const query: PaginateQuery = { path: '', filter: { colors: '$eq:1' } }
+
+                await expect(paginate<CatHairEntity>(query, catHairRepo, config)).rejects.toThrow(
+                    "Filter operator '$eq' is not allowed for column 'colors'"
+                )
             })
         })
 

--- a/src/paginate.spec.ts
+++ b/src/paginate.spec.ts
@@ -2495,6 +2495,73 @@ describe('paginate', () => {
         )
     })
 
+    it('should not order by a column that names no single value', async () => {
+        // `home` is a relation and `toys` a collection: neither has a value of its own to order by,
+        // and TypeORM compiles either into an ORDER BY over a column the paginated DISTINCT
+        // subquery never selects. Fall back to the default sort instead of emitting dead SQL.
+        for (const column of ['home', 'toys'] as const) {
+            const config: PaginateConfig<CatEntity> = {
+                sortableColumns: ['id', column],
+                defaultSortBy: [['id', 'ASC']],
+            }
+            const query: PaginateQuery = { path: '', sortBy: [[column, 'DESC']] }
+
+            const result = await paginate<CatEntity>(query, catRepo, config)
+
+            expect(result.meta.sortBy).toStrictEqual([['id', 'ASC']])
+            expect(result.data.map((cat) => cat.id)).toStrictEqual(cats.map((cat) => cat.id))
+        }
+    })
+
+    it('should still order through a to-many relation (a column past it names a value)', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id', 'toys.id'],
+            relations: { toys: true },
+            defaultSortBy: [['id', 'ASC']],
+        }
+        const query: PaginateQuery = { path: '', sortBy: [['toys.id', 'DESC']] }
+
+        const result = await paginate<CatEntity>(query, catRepo, config)
+
+        expect(result.meta.sortBy).toStrictEqual([['toys.id', 'DESC']])
+    })
+
+    it('should throw when $eq is not whitelisted, even spelled implicitly as a bare value', async () => {
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            filterableColumns: {
+                age: [FilterOperator.GT],
+            },
+            throwOnInvalidFilter: true,
+        }
+
+        for (const filter of ['$eq:5', '5']) {
+            const query: PaginateQuery = { path: '', filter: { age: filter } }
+            await expect(paginate<CatEntity>(query, catRepo, config)).rejects.toThrow(
+                "Filter operator '$eq' is not allowed for column 'age'"
+            )
+        }
+    })
+
+    it('should allow the $eq a whitelisted modifier negates or quantifies, named or not', async () => {
+        // `$not`/`$none` have no meaning without an operator to modify, and `$eq` is the implicit
+        // default — so whitelisting the modifier has to license the `$eq` it applies to.
+        const config: PaginateConfig<CatEntity> = {
+            sortableColumns: ['id'],
+            filterableColumns: {
+                name: [FilterSuffix.NOT],
+            },
+            throwOnInvalidFilter: true,
+        }
+
+        for (const filter of ['$not:Garfield', '$not:$eq:Garfield']) {
+            const query: PaginateQuery = { path: '', filter: { name: filter } }
+            const result = await paginate<CatEntity>(query, catRepo, config)
+            expect(result.data.map((cat) => cat.name)).not.toContain('Garfield')
+            expect(result.data.length).toBe(cats.length - 1)
+        }
+    })
+
     it('should silently ignore non-configured filter operator when throwOnInvalidFilter is false (default)', async () => {
         const config: PaginateConfig<CatEntity> = {
             sortableColumns: ['id'],
@@ -3762,6 +3829,49 @@ describe('paginate', () => {
         // Plain `json` columns (as opposed to `jsonb`) do not support the Postgres `@>`
         // containment operator, so $eq/$in must be routed through `#>>` text extraction
         // rather than TypeORM's JsonContains. These mirror the jsonb cases above.
+        describe('a json column itself is not a value', () => {
+            it('should reject a value filter on the json column rather than emit invalid SQL', async () => {
+                // Postgres has no `json = unknown`: comparing the column itself cannot be compiled,
+                // whatever the allowlist permits — `true` included.
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: { metadataJson: true },
+                    throwOnInvalidFilter: true,
+                }
+                const query: PaginateQuery = { path: '', filter: { metadataJson: '$eq:5' } }
+
+                await expect(paginate<CatHairEntity>(query, catHairRepo, config)).rejects.toThrow(
+                    /'metadataJson' is a json column and cannot be compared as a value/
+                )
+            })
+
+            it('should still ask a json column for emptiness', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id'],
+                    filterableColumns: { metadataJson: [FilterOperator.NULL] },
+                    throwOnInvalidFilter: true,
+                }
+                const query: PaginateQuery = { path: '', filter: { metadataJson: '$null' } }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.data.length).toBeGreaterThan(0)
+                expect(result.data.every((hair) => hair.metadataJson === null)).toBe(true)
+            })
+
+            it('should not order by a json column', async () => {
+                const config: PaginateConfig<CatHairEntity> = {
+                    sortableColumns: ['id', 'metadataJson'],
+                    defaultSortBy: [['id', 'ASC']],
+                }
+                const query: PaginateQuery = { path: '', sortBy: [['metadataJson', 'DESC']] }
+
+                const result = await paginate<CatHairEntity>(query, catHairRepo, config)
+
+                expect(result.meta.sortBy).toStrictEqual([['id', 'ASC']])
+            })
+        })
+
         describe('should be able to filter on json (non-jsonb) columns', () => {
             it('should filter a direct json column with a single value', async () => {
                 const config: PaginateConfig<CatHairEntity> = {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -35,6 +35,7 @@ import {
     isDateColumnType,
     isEntityKey,
     isOrderableColumn,
+    needsJsonbSortCast,
     isFindOperator,
     isISODate,
     isNil,
@@ -830,6 +831,18 @@ export async function paginate<T extends ObjectLiteral>(
                 alias = vcSortAlias
             } else if (isVirtualProperty) {
                 alias = quoteColumn(alias, isMySqlOrMariaDb)
+            }
+
+            if (!Array.isArray(order[0]) && needsJsonbSortCast(queryBuilder, order[0] as string)) {
+                // The cast makes this a raw expression, which the query builder no longer escapes
+                // for us — so escape the identifier here, or Postgres folds it to lower case.
+                const escape = (identifier: string) => queryBuilder.connection.driver.escape(identifier)
+                const separator = alias.indexOf('.')
+                const quoted =
+                    separator === -1
+                        ? escape(alias)
+                        : `${escape(alias.slice(0, separator))}.${escape(alias.slice(separator + 1))}`
+                alias = `${quoted}::jsonb`
             }
 
             if (isMySqlOrMariaDb) {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -834,15 +834,20 @@ export async function paginate<T extends ObjectLiteral>(
             }
 
             if (!Array.isArray(order[0]) && needsJsonbSortCast(queryBuilder, order[0] as string)) {
-                // The cast makes this a raw expression, which the query builder no longer escapes
-                // for us — so escape the identifier here, or Postgres folds it to lower case.
+                // Select the cast expression under an alias and order by that, the way a virtual or
+                // jsonb-path sort does. Ordering by the expression itself would not survive
+                // pagination: `take` wraps the query in a DISTINCT subquery, and the query builder
+                // resolves each ORDER BY back to a selected column — an identifier it did not
+                // escape itself is not one it can find ("__root" alias was not found).
                 const escape = (identifier: string) => queryBuilder.connection.driver.escape(identifier)
                 const separator = alias.indexOf('.')
                 const quoted =
                     separator === -1
                         ? escape(alias)
                         : `${escape(alias.slice(0, separator))}.${escape(alias.slice(separator + 1))}`
-                alias = `${quoted}::jsonb`
+                const jsonSortAlias = `${alias.replace(/[^a-zA-Z0-9]/g, '_')}_json_sort`.toLowerCase()
+                queryBuilder.addSelect(`${quoted}::jsonb`, jsonSortAlias)
+                alias = jsonSortAlias
             }
 
             if (isMySqlOrMariaDb) {

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -34,6 +34,7 @@ import {
     getQueryUrlComponents,
     isDateColumnType,
     isEntityKey,
+    isOrderableColumn,
     isFindOperator,
     isISODate,
     isNil,
@@ -468,11 +469,15 @@ export async function paginate<T extends ObjectLiteral>(
             }
             // A polymorphic group (e.g. `colA~colB`) is valid only when every
             // column in the group is sortable.
+            // A column that names no single value (a relation, a `json` blob) cannot be ordered
+            // by: TypeORM would compile it to SQL the database rejects. Drop it like any other
+            // unsortable column rather than emit a query that cannot run.
+            const sortable = (c: string) => isEntityKey(config.sortableColumns, c) && isOrderableColumn(metadata, c)
             if (Array.isArray(column)) {
-                if (column.length > 0 && column.every((c) => isEntityKey(config.sortableColumns, c))) {
+                if (column.length > 0 && column.every(sortable)) {
                     sortBy.push(order as Order<T>)
                 }
-            } else if (isEntityKey(config.sortableColumns, column)) {
+            } else if (sortable(column)) {
                 sortBy.push(order as Order<T>)
             }
         }


### PR DESCRIPTION
Three ways to ask for something the database cannot do. Each reached the database and failed there, instead of being answered.

Fixes #1111
Fixes #1109

### 1. `$eq` bypassed the operator allowlist (#1111)

```ts
filterableColumns: { age: [FilterOperator.GT] }   // filter.age=5 was accepted anyway
```

A column could not be narrowed to the operators it actually supports. The README promises to reject "a non-whitelisted filter operator/suffix"; that did not hold for the one operator every filter defaults to.

It is also how **#1109** happens: `filterableColumns: { list: [CONTAINS] }` still lets `$eq:1` through to an `int[]` column, which dies as `malformed array literal`. Refusing the operator refuses the 500.

`$eq` cannot simply be *required*, though — it is the operator a suffix negates and a quantifier quantifies, and it is implicit:

```ts
filterableColumns: { name: [FilterSuffix.NOT] }                 // $not:John  -> names no operator
filterableColumns: { 'home.pillows': [FilterQuantifier.NONE] }  // $none:red  -> names no operator
```

Requiring `EQ` in the list would make `[FilterSuffix.NOT]` and `[FilterQuantifier.NONE]` undeclarable. So: **a whitelisted modifier licenses the `$eq` it modifies** — `$not:John` and `$not:$eq:John` alike — and licenses nothing else. A standalone `$eq`, bare or spelled out, must be whitelisted like any other operator.

### 2. A value filter on a *top-level* `json` column emitted invalid SQL

```
operator does not exist: json = unknown
```

To be clear about what is already there: **`json` is cast to `jsonb` today.** `JsonContains` emits `<col>::jsonb @> :value`, exactly as `JSON_COLUMN_TYPES` documents. But it is only reached for a column `resolveJsonbPath` recognises, and that function returns early on a single-segment name:

```ts
const parts = column.split('.')
// A plain column name without dots is not a JSONB path — callers use checkIsJsonb directly.
if (parts.length < 2) {
    return notJsonb
}
```

So a key path (`metadataJson.length`) and a relation-prefixed column (`underCoat.metadataJson`) are both cast, and both work. A **top-level** `metadataJson` is not: it falls through to a plain `Equal()` → `col = :v` → the error above. Sorting it fails the same way (`could not identify an ordering operator for type json`).

Widening that early return so a top-level JSON column is recognised would route it through `JsonContains` and fix the crash. It would also change what `$eq` *means* on a top-level bare **`jsonb`** column — from equality (`=`, what it does today) to containment (`@>`, what `underCoat.metadata` does today). That divergence is worth resolving, but not silently, inside this PR.

So this PR takes the narrow option and refuses a value filter on the column itself. Its contents are still reached through a key path, and its emptiness through `$null`. Whole-document equality is also not something `$in`/`$btw` can spell — their values are comma-separated, and a JSON document contains commas.

### 3. Sorting by a column that names no single value emitted invalid SQL

```
column distinctAlias.__root_childId does not exist      -- a relation
could not identify an ordering operator for type json   -- a json column
```

A path that **ends on a relation** has no value of its own, so it is dropped like any other unsortable column and falls back to `defaultSortBy`.

A **`json` column** does name a value — Postgres just cannot order it, while `jsonb` has a total order and the cast between them is exact. So it is ordered *as* `jsonb`, and sorts like the `jsonb` column beside it.

Ordering **through** a to-many (`toys.id`) names a value and is unaffected — covered by a test.

### Tests

Each behaviour is covered: the allowlist rule and the `$not`/`$none` idioms it must keep working; the #1109 array case; the json column as filter target and as sort target, against its `jsonb` twin; and the relation-terminated sort.

Green on sqlite (350), postgres (381) and mariadb (348). The one failing Postgres test is the pre-existing virtual-column sort tie, which fails identically on an untouched `master` and is fixed by #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
